### PR TITLE
build: removed commitlint from CI workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -178,13 +178,13 @@ jobs:
     #    fail_ci_if_error: true
     #    verbose: true
 
-  commitlint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v4
+  # commitlint:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
+  #     - uses: wagoid/commitlint-github-action@v4
 
 
   docs:


### PR DESCRIPTION
commented out the relevant snippet in .github/workflows/CI.yml