### PR TITLE
maint: finish consolidation of dependencies

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -107,7 +107,7 @@ jobs:
       run: |
         poetry run python -m pytest tests -vv
 
-  test:
+  test-all-softdeps:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ homepage = "https://tsbootstrap.readthedocs.io/en/latest/"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.12"
+numpy= "<1.27,>=1.21"
 scikit-base = ">= 0.6.1,<0.8.0"
 scikit-learn = ">=0.24,<1.5.0"
 scipy = ">=1.11.0,<1.13.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ homepage = "https://tsbootstrap.readthedocs.io/en/latest/"
 [tool.poetry.dependencies]
 python = ">=3.10,<3.12"
 scikit-base = ">= 0.6.1,<0.8.0"
+scikit-learn = ">=0.24,<1.5.0"
 scipy = ">=1.11.0,<1.13.0"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,18 +23,17 @@ homepage = "https://tsbootstrap.readthedocs.io/en/latest/"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.12"
-scikit-base = ">= 0.6.1"
-cython = "~3.0"
-importlib-metadata = "~6.8"
-scipy = "~1.11"
-furo = "^2023.7.26"
+scikit-base = ">= 0.6.1,<0.8.0"
+scipy = ">=1.11.0,<1.13.0"
 
 [tool.poetry.dev-dependencies]
 # Add your dev dependencies here, e.g.
 black = "~23.10"
 blacken-docs = "~1.16"
+cython = "~3.0"
 github-actions = "~0.0"
 hypothesis = "~6.88"
+importlib-metadata = "~6.8"
 pip-tools = "~7.3"
 pre-commit = "~3.5"
 pytest = "~7.4"
@@ -49,27 +48,28 @@ sphinx = "~7.2"
 sphinx-rtd-theme = "^1.3.0"
 
 [tool.poetry.group.dev.dependencies]
-sphinx = "~7.2"
-sphinx-rtd-theme = "^1.3.0"
 bumpversion = "^0.6.0"
+furo = "^2023.7.26"
 jupyter = "*"
 myst-parser = "*"
 nbsphinx = "~0.8"
 numpydoc = "*"
 pydata-sphinx-theme = "*"
+sphinx = "~7.2"
 sphinx-copybutton = "*"
 sphinx-design = "<0.6.0"
 sphinx-gallery = "<0.15.0"
 sphinx-issues = "<4.0.0"
+sphinx-rtd-theme = "^1.3.0"
 sphinx-version-warning = "*"
 tabulate = "*"
 
 [tool.poetry.group.all_extras.dependencies]
-arch = ">=5.0.0, <6.0.0"
-hmmlearn = ">=0.3.0, <0.4.0"
-pyclustering = ">=0.10.0, <0.11.0"
-scikit_learn_extra = ">=0.3.0, <0.4.0"
-statsmodels = ">=0.12.1, <0.15.0"
+arch = ">=5.0.0,<6.0.0"
+hmmlearn = ">=0.3.0,<0.4.0"
+pyclustering = ">=0.10.0,<0.11.0"
+scikit_learn_extra = ">=0.3.0,<0.4.0"
+statsmodels = ">=0.12.1,<0.15.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ homepage = "https://tsbootstrap.readthedocs.io/en/latest/"
 [tool.poetry.dependencies]
 python = ">=3.10,<3.12"
 scikit-base = ">= 0.6.1"
-hmmlearn = "~0.3"
 cython = "~3.0"
 importlib-metadata = "~6.8"
 scipy = "~1.11"
@@ -67,6 +66,7 @@ tabulate = "*"
 
 [tool.poetry.group.all_extras.dependencies]
 arch = ">=5.0.0, <6.0.0"
+hmmlearn = ">=0.3.0, <0.4.0"
 pyclustering = ">=0.10.0, <0.11.0"
 scikit_learn_extra = ">=0.3.0, <0.4.0"
 statsmodels = ">=0.12.1, <0.15.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ homepage = "https://tsbootstrap.readthedocs.io/en/latest/"
 python = ">=3.10,<3.12"
 scikit-base = ">= 0.6.1"
 hmmlearn = "~0.3"
-pyclustering = "~0.10"
 scikit_learn_extra = "~0.3"
 cython = "~3.0"
 importlib-metadata = "~6.8"
@@ -69,6 +68,7 @@ tabulate = "*"
 
 [tool.poetry.group.all_extras.dependencies]
 arch = ">=5.0.0, <6.0.0"
+pyclustering = ">=0.10.0, <0.11.0"
 statsmodels = ">=0.12.1, <0.15.0"
 
 [build-system]

--- a/src/tsbootstrap/markov_sampler.py
+++ b/src/tsbootstrap/markov_sampler.py
@@ -3,8 +3,6 @@ from numbers import Integral
 
 import numpy as np
 import scipy.stats
-from hmmlearn import hmm
-from pyclustering.cluster.kmedians import kmedians  # type: ignore
 from sklearn.cluster import KMeans
 from sklearn.decomposition import PCA
 from sklearn.exceptions import NotFittedError
@@ -76,9 +74,12 @@ class BlockCompressor:
             )
 
         # once scikit-base object:
-        # set python_dependencies tag to "scikit-learn-extra" (due to MKedoids)
-        # import ame is sklearn_extra
+        # set python_dependencies tag depending on method
         # if method is "kmedoids"
+        # "scikit-learn-extra" (due to MKedoids)
+        # import name is sklearn_extra
+        # if method is "kmedians"
+        # "pyclustering" (due to KMedians)
 
     @property
     def method(self) -> str:
@@ -316,6 +317,8 @@ class BlockCompressor:
         -----
         This method uses the scipy implementation of k-medians clustering.
         """
+        from pyclustering.cluster.kmedians import kmedians  # type: ignore
+
         rng = np.random.default_rng(self.random_seed)
         initial_centers = rng.choice(block.flatten(), size=(1, block.shape[1]))
         kmedians_instance = kmedians(block, initial_centers)
@@ -421,6 +424,8 @@ class MarkovTransitionMatrixCalculator:
     >>> blocks = [np.random.rand(10, 5) for _ in range(50)]
     >>> transition_matrix = calculator.calculate_transition_probabilities(blocks)
     """
+
+    _tags = {"python_dependencies": "hmmlearn>=0.3.0"}
 
     @staticmethod
     def _calculate_dtw_distances(
@@ -690,7 +695,7 @@ class MarkovSampler:
         transmat_init: np.ndarray | None = None,
         means_init: np.ndarray | None = None,
         lengths: np.ndarray | None = None,
-    ) -> hmm.GaussianHMM:
+    ):
         """
         Fit a Gaussian Hidden Markov Model on the input data.
 
@@ -796,7 +801,7 @@ class MarkovSampler:
         transmat_init: np.ndarray | None,
         means_init: np.ndarray | None,
         idx: Integral,
-    ) -> hmm.GaussianHMM:
+    ):
         """
         Initialize a Gaussian Hidden Markov Model.
 
@@ -820,6 +825,8 @@ class MarkovSampler:
         -----
         This method is called by fit_hidden_markov_model. It is not intended to be called directly.
         """
+        from hmmlearn import hmm
+
         hmm_model = hmm.GaussianHMM(
             n_components=n_states,
             covariance_type="full",

--- a/src/tsbootstrap/markov_sampler.py
+++ b/src/tsbootstrap/markov_sampler.py
@@ -400,6 +400,43 @@ class BlockCompressor:
 
         return summaries
 
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+            There are currently no reserved values for aligners.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+        from skbase.utils.dependencies import _check_soft_dependencies
+
+        methods = [
+            "first",
+            "middle",
+            "last",
+            "mean",
+            "mode",
+            "median",
+            "kmeans",
+        ]
+        if _check_soft_dependencies("scikit-learn-extra", severity="none"):
+            methods.append("kmedoids")
+        if _check_soft_dependencies("pyclustering", severity="none"):
+            methods.append("kmedians")
+
+        return [{"method": method} for method in methods]
+
 
 class MarkovTransitionMatrixCalculator:
     """

--- a/src/tsbootstrap/markov_sampler.py
+++ b/src/tsbootstrap/markov_sampler.py
@@ -409,7 +409,6 @@ class BlockCompressor:
         parameter_set : str, default="default"
             Name of the set of test parameters to return, for use in tests. If no
             special parameters are defined for a value, will return `"default"` set.
-            There are currently no reserved values for aligners.
 
         Returns
         -------

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -21,6 +21,7 @@ from hypothesis.strategies import (
 )
 from numpy.linalg import LinAlgError
 from pyexpat import model
+from skbase.utils.dependencies import _check_soft_dependencies
 from tsbootstrap.base_bootstrap import BaseStatisticPreservingBootstrap
 from tsbootstrap.base_bootstrap_configs import (
     BaseDistributionBootstrapConfig,
@@ -562,6 +563,10 @@ class TestWholeMarkovBootstrap:
                 bootstrap._generate_samples_single_bootstrap(np.array(X))
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("hmmlearn", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 class TestBlockMarkovBootstrap:
     class TestPassingCases:
         @settings(deadline=None, max_examples=100)

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -405,6 +405,10 @@ markov_method_strategy = sampled_from(
 #                 bootstrap._generate_samples_single_bootstrap(np.array(X))
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("hmmlearn", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 class TestWholeMarkovBootstrap:
     class TestPassingCases:
         @settings(deadline=None, max_examples=10)

--- a/tests/test_markov_sampler.py
+++ b/tests/test_markov_sampler.py
@@ -4,7 +4,6 @@ from typing import Any
 import numpy as np
 import pytest
 import scipy
-from hmmlearn import hmm
 from hypothesis import given, settings
 from hypothesis import strategies as st
 from pytest import approx
@@ -931,6 +930,8 @@ class TestMarkovSampler:
 
                 The test asserts that the returned model is an instance of hmm.GaussianHMM and the number of states matches the input.
                 """
+                from hmmlearn import hmm
+
                 model = MarkovSampler(
                     n_iter_hmm=n_iter_hmm, n_fits_hmm=n_fits_hmm
                 ).fit_hidden_markov_model(X, n_states)
@@ -942,6 +943,8 @@ class TestMarkovSampler:
             def test_fit_hidden_markov_model_with_transmat_means_init(
                 self, data
             ):
+                from hmmlearn import hmm
+
                 X = np.random.rand(50, 1)
                 n_states = 2
                 transmat_init = data.draw(valid_transmat())

--- a/tests/test_markov_sampler.py
+++ b/tests/test_markov_sampler.py
@@ -7,18 +7,13 @@ import scipy
 from hypothesis import given, settings
 from hypothesis import strategies as st
 from pytest import approx
+from skbase.utils.dependencies import _check_soft_dependencies
 from sklearn.decomposition import PCA
 from tsbootstrap import (
     BlockCompressor,
     MarkovSampler,
     MarkovTransitionMatrixCalculator,
 )
-
-dtaidistance_installed = True
-try:
-    from dtaidistance import dtw_ndim  # type: ignore
-except ImportError:
-    dtaidistance_installed = False
 
 
 def generate_random_blocks(
@@ -55,7 +50,8 @@ def generate_random_blocks(
 
 # Use pytest.mark.skipif decorator to skip this class if dtaidistance is not installed
 @pytest.mark.skipif(
-    not dtaidistance_installed, reason="dtaidistance package not installed"
+    not _check_soft_dependencies("dtaidistance", severity="none"),
+    reason="skip test if required soft dependency not available",
 )
 class TestMarkovTransitionMatrixCalculator:
     class TestCalculateTransitionProbabilities:
@@ -857,6 +853,10 @@ invalid_test_data_list = [
 ]
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("hmmlearn", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 class TestMarkovSampler:
     class TestInitAndGettersAndSetters:
         class TestPassingCases:
@@ -1039,8 +1039,8 @@ class TestMarkovSampler:
                 assert states.shape == (total_rows,)
 
             @pytest.mark.skipif(
-                not dtaidistance_installed,
-                reason="dtaidistance package not installed",
+                not _check_soft_dependencies("dtaidistance", severity="none"),
+                reason="skip test if required soft dependency not available",
             )
             @pytest.mark.parametrize(
                 "blocks, n_states, n_iter_hmm, n_fits_hmm",

--- a/tests/test_markov_sampler.py
+++ b/tests/test_markov_sampler.py
@@ -192,20 +192,10 @@ class TestMarkovTransitionMatrixCalculator:
                     generate_random_blocks(n_blocks, block_size)
 
 
+methods = [x["methods"] for x in BlockCompressor.get_test_params()]
+
 # Hypothesis strategies
-valid_method = st.sampled_from(
-    [
-        "first",
-        "middle",
-        "last",
-        "mean",
-        "mode",
-        "median",
-        "kmeans",
-        "kmedians",
-        "kmedoids",
-    ]
-)
+valid_method = st.sampled_from(methods)
 invalid_method = st.text().filter(
     lambda x: x
     not in [

--- a/tests/test_markov_sampler.py
+++ b/tests/test_markov_sampler.py
@@ -192,7 +192,7 @@ class TestMarkovTransitionMatrixCalculator:
                     generate_random_blocks(n_blocks, block_size)
 
 
-methods = [x["methods"] for x in BlockCompressor.get_test_params()]
+methods = [x["method"] for x in BlockCompressor.get_test_params()]
 
 # Hypothesis strategies
 valid_method = st.sampled_from(methods)

--- a/tests/test_ranklags.py
+++ b/tests/test_ranklags.py
@@ -2,9 +2,14 @@ from numbers import Integral
 
 import numpy as np
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 from tsbootstrap.ranklags import RankLags
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 class TestRankLags:
     class TestPassingCases:
         def test_basic_initialization(self):

--- a/tests/test_time_series_simulator.py
+++ b/tests/test_time_series_simulator.py
@@ -1,13 +1,8 @@
 import numpy as np
 import pytest
-from arch import arch_model
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 from numpy.random import Generator, default_rng
-from statsmodels.tsa.ar_model import AutoReg
-from statsmodels.tsa.arima.model import ARIMA
-from statsmodels.tsa.statespace.sarimax import SARIMAX
-from statsmodels.tsa.vector_ar.var_model import VAR
 from tsbootstrap import TimeSeriesSimulator
 from tsbootstrap.utils.odds_and_ends import assert_arrays_compare
 
@@ -33,18 +28,24 @@ float_array_unique = st.just(np.random.rand(10, 1))
 
 
 def ar_model_strategy():
+    from statsmodels.tsa.ar_model import AutoReg
+
     return st.builds(
         lambda data: AutoReg(data, lags=1).fit(), float_array_unique
     )
 
 
 def arima_model_strategy():
+    from statsmodels.tsa.arima.model import ARIMA
+
     return st.builds(
         lambda data: ARIMA(data, order=(1, 0, 0)).fit(), float_array_unique
     )
 
 
 def sarima_model_strategy():
+    from statsmodels.tsa.statespace.sarimax import SARIMAX
+
     return st.builds(
         lambda data: SARIMAX(
             data, order=(1, 0, 0), seasonal_order=(0, 0, 0, 0)
@@ -54,6 +55,8 @@ def sarima_model_strategy():
 
 
 def var_model_strategy():
+    from statsmodels.tsa.vector_ar.var_model import VAR
+
     return st.builds(
         lambda data: VAR(data).fit(maxlags=1),
         float_array_unique.map(lambda x: np.column_stack([x, x])),
@@ -61,6 +64,8 @@ def var_model_strategy():
 
 
 def scale_and_fit_arch(data):
+    from arch import arch_model
+
     scaled_data = data * np.sqrt(100 / np.var(data))
     return arch_model(scaled_data).fit()
 

--- a/tests/test_time_series_simulator.py
+++ b/tests/test_time_series_simulator.py
@@ -88,7 +88,7 @@ def arch_model_strategy():
 class TestARModel:
     class TestPassingCases:
         @given(
-            fitted_model=ar_model_strategy,
+            fitted_model=ar_model_strategy(),
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -96,10 +96,10 @@ class TestARModel:
         )
         def test_init_valid(self, fitted_model, X_fitted, rng):
             """Test that AR model initialization works with valid inputs."""
-            TimeSeriesSimulator(fitted_model(), X_fitted, rng)
+            TimeSeriesSimulator(fitted_model, X_fitted, rng)
 
         @given(
-            fitted_model=ar_model_strategy,
+            fitted_model=ar_model_strategy(),
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -107,12 +107,11 @@ class TestARModel:
         )
         def test_fitted_model_valid(self, fitted_model, X_fitted, rng):
             """Test that AR model fitted_model property getter and setter work correctly."""
-            model = fitted_model()
-            simulator = TimeSeriesSimulator(model, X_fitted, rng)
-            assert simulator.fitted_model == model
+            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
+            assert simulator.fitted_model == fitted_model
 
         @given(
-            fitted_model=ar_model_strategy,
+            fitted_model=ar_model_strategy(),
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -120,11 +119,11 @@ class TestARModel:
         )
         def test_X_fitted_valid(self, fitted_model, X_fitted, rng):
             """Test that AR model X_fitted property getter and setter work correctly."""
-            simulator = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
+            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
             assert np.allclose(simulator.X_fitted, X_fitted)
 
         @given(
-            fitted_model=ar_model_strategy,
+            fitted_model=ar_model_strategy(),
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -132,11 +131,11 @@ class TestARModel:
         )
         def test_rng_valid(self, fitted_model, X_fitted, rng):
             """Test that AR model rng property getter and setter work correctly."""
-            simulator = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
+            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
             assert isinstance(simulator.rng, Generator)
 
         @given(
-            fitted_model=ar_model_strategy,
+            fitted_model=ar_model_strategy(),
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -155,13 +154,13 @@ class TestARModel:
             resids,
         ):
             """Test that AR model simulation works with valid inputs."""
-            simulator = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
+            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
             simulator.simulate_ar_process(
                 resids_lags, resids_coefs.reshape(1, -1), resids
             )
 
         @given(
-            fitted_model=ar_model_strategy,
+            fitted_model=ar_model_strategy(),
             X_fitted=float_array_unique,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -184,13 +183,13 @@ class TestARModel:
             large_resids_lags = np.repeat(resids_lags, 10)
             large_resids_coefs = np.repeat(resids_coefs, 10).reshape(1, -1)
             large_resids = np.repeat(resids, 10)
-            simulator = TimeSeriesSimulator(fitted_model(), large_X_fitted, rng)
+            simulator = TimeSeriesSimulator(fitted_model, large_X_fitted, rng)
             simulator.simulate_ar_process(
                 large_resids_lags, large_resids_coefs, large_resids
             )
 
         @given(
-            fitted_model=ar_model_strategy,
+            fitted_model=ar_model_strategy(),
             X_fitted=float_array,
             resids_lags=integer_array,
             resids_coefs=float_array,
@@ -203,20 +202,20 @@ class TestARModel:
             rng_seed = 12345
 
             rng1 = np.random.default_rng(rng_seed)
-            simulator1 = TimeSeriesSimulator(fitted_model(), X_fitted, rng1)
+            simulator1 = TimeSeriesSimulator(fitted_model, X_fitted, rng1)
             simulated_series1 = simulator1.simulate_ar_process(
                 resids_lags, resids_coefs.reshape(1, -1), resids
             )
 
             rng2 = np.random.default_rng(rng_seed)
-            simulator2 = TimeSeriesSimulator(fitted_model(), X_fitted, rng2)
+            simulator2 = TimeSeriesSimulator(fitted_model, X_fitted, rng2)
             simulated_series2 = simulator2.simulate_ar_process(
                 resids_lags, resids_coefs.reshape(1, -1), resids
             )
             assert_arrays_compare(simulated_series1, simulated_series2)
 
         @given(
-            fitted_model=ar_model_strategy,
+            fitted_model=ar_model_strategy(),
             X_fitted=float_array,
             resids_lags=integer_array,
             resids_coefs=float_array,
@@ -227,12 +226,12 @@ class TestARModel:
         ):
             """Test that AR model simulation gives different results with different rng."""
             rng = np.random.default_rng()
-            simulator1 = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
+            simulator1 = TimeSeriesSimulator(fitted_model, X_fitted, rng)
             simulated_series1 = simulator1.simulate_ar_process(
                 resids_lags, resids_coefs.reshape(1, -1), resids
             )
 
-            simulator2 = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
+            simulator2 = TimeSeriesSimulator(fitted_model, X_fitted, rng)
             simulated_series2 = simulator2.simulate_ar_process(
                 resids_lags, resids_coefs.reshape(1, -1), resids
             )
@@ -263,7 +262,7 @@ class TestARModel:
                 TimeSeriesSimulator(fitted_model, X_fitted, rng)
 
         @given(
-            fitted_model=ar_model_strategy,
+            fitted_model=ar_model_strategy(),
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -282,14 +281,14 @@ class TestARModel:
             resids,
         ):
             """Test that AR model simulation fails with invalid resids_lags."""
-            simulator = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
+            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
             with pytest.raises((ValueError, TypeError)):
                 simulator.simulate_ar_process(
                     resids_lags, resids_coefs.reshape(1, -1), resids
                 )
 
         @given(
-            fitted_model=ar_model_strategy,
+            fitted_model=ar_model_strategy(),
             X_fitted=st.none() | integer_array | st.text(),
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -299,7 +298,7 @@ class TestARModel:
             """Test that AR model initialization fails with invalid X_fitted."""
             if not isinstance(X_fitted, np.ndarray):
                 with pytest.raises(TypeError):
-                    TimeSeriesSimulator(fitted_model(), X_fitted, rng)
+                    TimeSeriesSimulator(fitted_model, X_fitted, rng)
 
 
 @pytest.mark.skipif(
@@ -310,7 +309,7 @@ class TestARIMAModel:
     class TestPassingCases:
         @settings(suppress_health_check=(HealthCheck.too_slow,))
         @given(
-            fitted_model=arima_model_strategy,
+            fitted_model=arima_model_strategy(),
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -318,11 +317,11 @@ class TestARIMAModel:
         )
         def test_init_valid(self, fitted_model, X_fitted, rng):
             """Test that ARIMA model initialization works with valid inputs."""
-            TimeSeriesSimulator(fitted_model(), X_fitted, rng)
+            TimeSeriesSimulator(fitted_model, X_fitted, rng)
 
         @settings(suppress_health_check=(HealthCheck.too_slow,))
         @given(
-            fitted_model=arima_model_strategy,
+            fitted_model=arima_model_strategy(),
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -330,13 +329,12 @@ class TestARIMAModel:
         )
         def test_fitted_model_valid(self, fitted_model, X_fitted, rng):
             """Test that ARIMA model fitted_model property getter and setter work correctly."""
-            model = fitted_model()
-            simulator = TimeSeriesSimulator(model, X_fitted, rng)
-            assert simulator.fitted_model == model
+            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
+            assert simulator.fitted_model == fitted_model
 
         @settings(suppress_health_check=(HealthCheck.too_slow,))
         @given(
-            fitted_model=arima_model_strategy,
+            fitted_model=arima_model_strategy(),
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -344,12 +342,12 @@ class TestARIMAModel:
         )
         def test_X_fitted_valid(self, fitted_model, X_fitted, rng):
             """Test that ARIMA model X_fitted property getter and setter work correctly."""
-            simulator = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
+            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
             assert np.allclose(simulator.X_fitted, X_fitted)
 
         @settings(suppress_health_check=(HealthCheck.too_slow,))
         @given(
-            fitted_model=arima_model_strategy,
+            fitted_model=arima_model_strategy(),
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -357,11 +355,11 @@ class TestARIMAModel:
         )
         def test_rng_valid(self, fitted_model, X_fitted, rng):
             """Test that ARIMA model rng property getter and setter work correctly."""
-            simulator = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
+            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
             assert isinstance(simulator.rng, Generator)
 
         @given(
-            fitted_model=arima_model_strategy,
+            fitted_model=arima_model_strategy(),
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -371,7 +369,7 @@ class TestARIMAModel:
             self, fitted_model, X_fitted, rng
         ):
             """Test that ARIMA model simulation works with valid inputs."""
-            simulator = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
+            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
             simulator.simulate_non_ar_process()
 
         # TODO: even with the same rng object, simulation results are different. Investigate why.
@@ -410,7 +408,7 @@ class TestARIMAModel:
                 TimeSeriesSimulator(fitted_model, X_fitted, rng)
 
         @given(
-            fitted_model=arima_model_strategy,
+            fitted_model=arima_model_strategy(),
             X_fitted=st.none() | integer_array | st.text(),
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -420,7 +418,7 @@ class TestARIMAModel:
             """Test that ARIMA model initialization fails with invalid X_fitted."""
             if not isinstance(X_fitted, np.ndarray):
                 with pytest.raises(TypeError):
-                    TimeSeriesSimulator(fitted_model(), X_fitted, rng)
+                    TimeSeriesSimulator(fitted_model, X_fitted, rng)
 
 
 @pytest.mark.skipif(
@@ -430,7 +428,7 @@ class TestARIMAModel:
 class TestSARIMAModel:
     class TestPassingCases:
         @given(
-            fitted_model=sarima_model_strategy,
+            fitted_model=sarima_model_strategy(),
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -438,10 +436,10 @@ class TestSARIMAModel:
         )
         def test_init_valid(self, fitted_model, X_fitted, rng):
             """Test that SARIMA model initialization works with valid inputs."""
-            TimeSeriesSimulator(fitted_model(), X_fitted, rng)
+            TimeSeriesSimulator(fitted_model, X_fitted, rng)
 
         @given(
-            fitted_model=sarima_model_strategy,
+            fitted_model=sarima_model_strategy(),
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -449,12 +447,11 @@ class TestSARIMAModel:
         )
         def test_fitted_model_valid(self, fitted_model, X_fitted, rng):
             """Test that SARIMA model fitted_model property getter and setter work correctly."""
-            model = fitted_model()
-            simulator = TimeSeriesSimulator(model, X_fitted, rng)
-            assert simulator.fitted_model == model
+            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
+            assert simulator.fitted_model == fitted_model
 
         @given(
-            fitted_model=sarima_model_strategy,
+            fitted_model=sarima_model_strategy(),
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -462,11 +459,11 @@ class TestSARIMAModel:
         )
         def test_X_fitted_valid(self, fitted_model, X_fitted, rng):
             """Test that SARIMA model X_fitted property getter and setter work correctly."""
-            simulator = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
+            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
             assert np.allclose(simulator.X_fitted, X_fitted)
 
         @given(
-            fitted_model=sarima_model_strategy,
+            fitted_model=sarima_model_strategy(),
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -474,11 +471,11 @@ class TestSARIMAModel:
         )
         def test_rng_valid(self, fitted_model, X_fitted, rng):
             """Test that SARIMA model rng property getter and setter work correctly."""
-            simulator = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
+            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
             assert isinstance(simulator.rng, Generator)
 
         @given(
-            fitted_model=sarima_model_strategy,
+            fitted_model=sarima_model_strategy(),
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -488,7 +485,7 @@ class TestSARIMAModel:
             self, fitted_model, X_fitted, rng
         ):
             """Test that SARIMA model simulation works with valid inputs."""
-            simulator = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
+            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
             simulator.simulate_non_ar_process()
 
         # TODO: even with the same rng object, simulation results are different. Investigate why.
@@ -534,7 +531,7 @@ class TestSARIMAModel:
 class TestVARModel:
     class TestPassingCases:
         @given(
-            fitted_model=var_model_strategy,
+            fitted_model=var_model_strategy(),
             X_fitted=float_array.map(lambda x: np.column_stack([x, x])),
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -542,10 +539,10 @@ class TestVARModel:
         )
         def test_init_valid(self, fitted_model, X_fitted, rng):
             """Test that VAR model initialization works with valid inputs."""
-            TimeSeriesSimulator(fitted_model(), X_fitted, rng)
+            TimeSeriesSimulator(fitted_model, X_fitted, rng)
 
         @given(
-            fitted_model=var_model_strategy,
+            fitted_model=var_model_strategy(),
             X_fitted=float_array.map(lambda x: np.column_stack([x, x])),
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -553,12 +550,11 @@ class TestVARModel:
         )
         def test_fitted_model_valid(self, fitted_model, X_fitted, rng):
             """Test that VAR model fitted_model property getter and setter work correctly."""
-            model = fitted_model()
-            simulator = TimeSeriesSimulator(model, X_fitted, rng)
-            assert simulator.fitted_model == model
+            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
+            assert simulator.fitted_model == fitted_model
 
         @given(
-            fitted_model=var_model_strategy,
+            fitted_model=var_model_strategy(),
             X_fitted=float_array.map(lambda x: np.column_stack([x, x])),
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -566,11 +562,11 @@ class TestVARModel:
         )
         def test_X_fitted_valid(self, fitted_model, X_fitted, rng):
             """Test that VAR model X_fitted property getter and setter work correctly."""
-            simulator = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
+            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
             assert np.allclose(simulator.X_fitted, X_fitted)
 
         @given(
-            fitted_model=var_model_strategy,
+            fitted_model=var_model_strategy(),
             X_fitted=float_array.map(lambda x: np.column_stack([x, x])),
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -578,11 +574,11 @@ class TestVARModel:
         )
         def test_rng_valid(self, fitted_model, X_fitted, rng):
             """Test that VAR model rng property getter and setter work correctly."""
-            simulator = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
+            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
             assert isinstance(simulator.rng, Generator)
 
         @given(
-            fitted_model=var_model_strategy,
+            fitted_model=var_model_strategy(),
             X_fitted=float_array.map(lambda x: np.column_stack([x, x])),
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -593,13 +589,13 @@ class TestVARModel:
         ):
             """Test that VAR model simulation works with valid inputs."""
             print(f"X_fitted.shape = {X_fitted.shape}")
-            simulator = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
+            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
             print(f"simulator.X_fitted.shape = {simulator.X_fitted.shape}")
             print(f"simulator.burnin = {simulator.burnin}")
             simulator.simulate_non_ar_process()
 
         @given(
-            fitted_model=var_model_strategy,
+            fitted_model=var_model_strategy(),
             X_fitted=float_array.map(lambda x: np.column_stack([x, x])),
         )
         def test_simulate_non_ar_same_rng(self, fitted_model, X_fitted):
@@ -607,11 +603,11 @@ class TestVARModel:
             rng_seed = 12345
 
             rng1 = np.random.default_rng(rng_seed)
-            simulator1 = TimeSeriesSimulator(fitted_model(), X_fitted, rng1)
+            simulator1 = TimeSeriesSimulator(fitted_model, X_fitted, rng1)
             simulated_series1 = simulator1.simulate_non_ar_process()
 
             rng2 = np.random.default_rng(rng_seed)
-            simulator2 = TimeSeriesSimulator(fitted_model(), X_fitted, rng2)
+            simulator2 = TimeSeriesSimulator(fitted_model, X_fitted, rng2)
             simulated_series2 = simulator2.simulate_non_ar_process()
 
             print(f"simulated_series1 = {simulated_series1}")
@@ -620,16 +616,16 @@ class TestVARModel:
             assert_arrays_compare(simulated_series1, simulated_series2)
 
         @given(
-            fitted_model=var_model_strategy,
+            fitted_model=var_model_strategy(),
             X_fitted=float_array.map(lambda x: np.column_stack([x, x])),
         )
         def test_simulate_non_ar_different_rng(self, fitted_model, X_fitted):
             """Test that SARIMA model simulation gives same results with same rng."""
             rng = np.random.default_rng()
-            simulator1 = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
+            simulator1 = TimeSeriesSimulator(fitted_model, X_fitted, rng)
             simulated_series1 = simulator1.simulate_non_ar_process()
 
-            simulator2 = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
+            simulator2 = TimeSeriesSimulator(fitted_model, X_fitted, rng)
             simulated_series2 = simulator2.simulate_non_ar_process()
 
             assert_arrays_compare(
@@ -663,7 +659,7 @@ class TestVARModel:
 class TestARCHModel:
     class TestPassingCases:
         @given(
-            fitted_model=arch_model_strategy,
+            fitted_model=arch_model_strategy(),
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -671,10 +667,10 @@ class TestARCHModel:
         )
         def test_init_valid(self, fitted_model, X_fitted, rng):
             """Test that ARCH model initialization works with valid inputs."""
-            TimeSeriesSimulator(fitted_model(), X_fitted, rng)
+            TimeSeriesSimulator(fitted_model, X_fitted, rng)
 
         @given(
-            fitted_model=arch_model_strategy,
+            fitted_model=arch_model_strategy(),
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -682,12 +678,11 @@ class TestARCHModel:
         )
         def test_fitted_model_valid(self, fitted_model, X_fitted, rng):
             """Test that ARCH model fitted_model property getter and setter work correctly."""
-            model = fitted_model()
-            simulator = TimeSeriesSimulator(model, X_fitted, rng)
-            assert simulator.fitted_model == model
+            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
+            assert simulator.fitted_model == fitted_model
 
         @given(
-            fitted_model=arch_model_strategy,
+            fitted_model=arch_model_strategy(),
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -695,11 +690,11 @@ class TestARCHModel:
         )
         def test_X_fitted_valid(self, fitted_model, X_fitted, rng):
             """Test that ARCH model X_fitted property getter and setter work correctly."""
-            simulator = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
+            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
             assert np.allclose(simulator.X_fitted, X_fitted)
 
         @given(
-            fitted_model=arch_model_strategy,
+            fitted_model=arch_model_strategy(),
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -707,11 +702,11 @@ class TestARCHModel:
         )
         def test_rng_valid(self, fitted_model, X_fitted, rng):
             """Test that ARCH model rng property getter and setter work correctly."""
-            simulator = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
+            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
             assert isinstance(simulator.rng, Generator)
 
         @given(
-            fitted_model=arch_model_strategy,
+            fitted_model=arch_model_strategy(),
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -721,7 +716,7 @@ class TestARCHModel:
             self, fitted_model, X_fitted, rng
         ):
             """Test that ARCH model simulation works with valid inputs."""
-            simulator = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
+            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
             simulator.simulate_non_ar_process()
 
         # TODO: even with the same rng object, simulation results are different. Investigate why.
@@ -760,7 +755,7 @@ class TestARCHModel:
                 TimeSeriesSimulator(fitted_model, X_fitted, rng)
 
         @given(
-            fitted_model=arch_model_strategy,
+            fitted_model=arch_model_strategy(),
             X_fitted=st.none() | st.integers() | st.text(),
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -769,14 +764,14 @@ class TestARCHModel:
         def test_init_invalid_X_fitted(self, fitted_model, X_fitted, rng):
             """Test that ARCH model initialization fails with invalid X_fitted."""
             with pytest.raises(TypeError):
-                TimeSeriesSimulator(fitted_model(), X_fitted, rng)
+                TimeSeriesSimulator(fitted_model, X_fitted, rng)
 
         @given(
-            fitted_model=arch_model_strategy,
+            fitted_model=arch_model_strategy(),
             X_fitted=float_array,
             rng=st.floats() | st.text(),
         )
         def test_init_invalid_rng(self, fitted_model, X_fitted, rng):
             """Test that ARCH model initialization fails with invalid rng."""
             with pytest.raises(TypeError):
-                TimeSeriesSimulator(fitted_model(), X_fitted, rng)
+                TimeSeriesSimulator(fitted_model, X_fitted, rng)

--- a/tests/test_time_series_simulator.py
+++ b/tests/test_time_series_simulator.py
@@ -28,38 +28,44 @@ float_array = st.lists(
 float_array_unique = st.just(np.random.rand(10, 1))
 
 
-def ar_model_strategy():
+def get_model(str, data):
     from statsmodels.tsa.ar_model import AutoReg
+    from statsmodels.tsa.arima.model import ARIMA
+    from statsmodels.tsa.statespace.sarimax import SARIMAX
+    from statsmodels.tsa.vector_ar.var_model import VAR
 
+    if str == "ar":
+        return AutoReg(data, lags=1)
+    elif str == "arima":
+        return ARIMA(data, order=(1, 0, 0))
+    elif str == "sarima":
+        return SARIMAX(data, order=(1, 0, 0), seasonal_order=(0, 0, 0, 0))
+    elif str == "var":
+        return VAR(data)
+    
+
+def ar_model_strategy():
     return st.builds(
-        lambda data: AutoReg(data, lags=1).fit(), float_array_unique
+        lambda data: get_model("ar", data).fit(), float_array_unique
     )
 
 
 def arima_model_strategy():
-    from statsmodels.tsa.arima.model import ARIMA
-
     return st.builds(
-        lambda data: ARIMA(data, order=(1, 0, 0)).fit(), float_array_unique
+        lambda data: get_model("arima", data).fit(), float_array_unique
     )
 
 
 def sarima_model_strategy():
-    from statsmodels.tsa.statespace.sarimax import SARIMAX
-
     return st.builds(
-        lambda data: SARIMAX(
-            data, order=(1, 0, 0), seasonal_order=(0, 0, 0, 0)
-        ).fit(),
+        lambda data: get_model("sarima", data).fit(),
         float_array_unique,
     )
 
 
 def var_model_strategy():
-    from statsmodels.tsa.vector_ar.var_model import VAR
-
     return st.builds(
-        lambda data: VAR(data).fit(maxlags=1),
+        lambda data: get_model("var", data).fit(maxlags=1),
         float_array_unique.map(lambda x: np.column_stack([x, x])),
     )
 

--- a/tests/test_time_series_simulator.py
+++ b/tests/test_time_series_simulator.py
@@ -77,7 +77,7 @@ def arch_model_strategy():
 class TestARModel:
     class TestPassingCases:
         @given(
-            fitted_model=ar_model_strategy(),
+            fitted_model=ar_model_strategy,
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -85,10 +85,10 @@ class TestARModel:
         )
         def test_init_valid(self, fitted_model, X_fitted, rng):
             """Test that AR model initialization works with valid inputs."""
-            TimeSeriesSimulator(fitted_model, X_fitted, rng)
+            TimeSeriesSimulator(fitted_model(), X_fitted, rng)
 
         @given(
-            fitted_model=ar_model_strategy(),
+            fitted_model=ar_model_strategy,
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -96,11 +96,12 @@ class TestARModel:
         )
         def test_fitted_model_valid(self, fitted_model, X_fitted, rng):
             """Test that AR model fitted_model property getter and setter work correctly."""
-            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
-            assert simulator.fitted_model == fitted_model
+            model = fitted_model()
+            simulator = TimeSeriesSimulator(model, X_fitted, rng)
+            assert simulator.fitted_model == model
 
         @given(
-            fitted_model=ar_model_strategy(),
+            fitted_model=ar_model_strategy,
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -108,11 +109,11 @@ class TestARModel:
         )
         def test_X_fitted_valid(self, fitted_model, X_fitted, rng):
             """Test that AR model X_fitted property getter and setter work correctly."""
-            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
+            simulator = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
             assert np.allclose(simulator.X_fitted, X_fitted)
 
         @given(
-            fitted_model=ar_model_strategy(),
+            fitted_model=ar_model_strategy,
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -120,11 +121,11 @@ class TestARModel:
         )
         def test_rng_valid(self, fitted_model, X_fitted, rng):
             """Test that AR model rng property getter and setter work correctly."""
-            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
+            simulator = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
             assert isinstance(simulator.rng, Generator)
 
         @given(
-            fitted_model=ar_model_strategy(),
+            fitted_model=ar_model_strategy,
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -143,13 +144,13 @@ class TestARModel:
             resids,
         ):
             """Test that AR model simulation works with valid inputs."""
-            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
+            simulator = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
             simulator.simulate_ar_process(
                 resids_lags, resids_coefs.reshape(1, -1), resids
             )
 
         @given(
-            fitted_model=ar_model_strategy(),
+            fitted_model=ar_model_strategy,
             X_fitted=float_array_unique,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -172,13 +173,13 @@ class TestARModel:
             large_resids_lags = np.repeat(resids_lags, 10)
             large_resids_coefs = np.repeat(resids_coefs, 10).reshape(1, -1)
             large_resids = np.repeat(resids, 10)
-            simulator = TimeSeriesSimulator(fitted_model, large_X_fitted, rng)
+            simulator = TimeSeriesSimulator(fitted_model(), large_X_fitted, rng)
             simulator.simulate_ar_process(
                 large_resids_lags, large_resids_coefs, large_resids
             )
 
         @given(
-            fitted_model=ar_model_strategy(),
+            fitted_model=ar_model_strategy,
             X_fitted=float_array,
             resids_lags=integer_array,
             resids_coefs=float_array,
@@ -191,20 +192,20 @@ class TestARModel:
             rng_seed = 12345
 
             rng1 = np.random.default_rng(rng_seed)
-            simulator1 = TimeSeriesSimulator(fitted_model, X_fitted, rng1)
+            simulator1 = TimeSeriesSimulator(fitted_model(), X_fitted, rng1)
             simulated_series1 = simulator1.simulate_ar_process(
                 resids_lags, resids_coefs.reshape(1, -1), resids
             )
 
             rng2 = np.random.default_rng(rng_seed)
-            simulator2 = TimeSeriesSimulator(fitted_model, X_fitted, rng2)
+            simulator2 = TimeSeriesSimulator(fitted_model(), X_fitted, rng2)
             simulated_series2 = simulator2.simulate_ar_process(
                 resids_lags, resids_coefs.reshape(1, -1), resids
             )
             assert_arrays_compare(simulated_series1, simulated_series2)
 
         @given(
-            fitted_model=ar_model_strategy(),
+            fitted_model=ar_model_strategy,
             X_fitted=float_array,
             resids_lags=integer_array,
             resids_coefs=float_array,
@@ -215,12 +216,12 @@ class TestARModel:
         ):
             """Test that AR model simulation gives different results with different rng."""
             rng = np.random.default_rng()
-            simulator1 = TimeSeriesSimulator(fitted_model, X_fitted, rng)
+            simulator1 = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
             simulated_series1 = simulator1.simulate_ar_process(
                 resids_lags, resids_coefs.reshape(1, -1), resids
             )
 
-            simulator2 = TimeSeriesSimulator(fitted_model, X_fitted, rng)
+            simulator2 = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
             simulated_series2 = simulator2.simulate_ar_process(
                 resids_lags, resids_coefs.reshape(1, -1), resids
             )
@@ -251,7 +252,7 @@ class TestARModel:
                 TimeSeriesSimulator(fitted_model, X_fitted, rng)
 
         @given(
-            fitted_model=ar_model_strategy(),
+            fitted_model=ar_model_strategy,
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -270,14 +271,14 @@ class TestARModel:
             resids,
         ):
             """Test that AR model simulation fails with invalid resids_lags."""
-            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
+            simulator = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
             with pytest.raises((ValueError, TypeError)):
                 simulator.simulate_ar_process(
                     resids_lags, resids_coefs.reshape(1, -1), resids
                 )
 
         @given(
-            fitted_model=ar_model_strategy(),
+            fitted_model=ar_model_strategy,
             X_fitted=st.none() | integer_array | st.text(),
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -287,14 +288,14 @@ class TestARModel:
             """Test that AR model initialization fails with invalid X_fitted."""
             if not isinstance(X_fitted, np.ndarray):
                 with pytest.raises(TypeError):
-                    TimeSeriesSimulator(fitted_model, X_fitted, rng)
+                    TimeSeriesSimulator(fitted_model(), X_fitted, rng)
 
 
 class TestARIMAModel:
     class TestPassingCases:
         @settings(suppress_health_check=(HealthCheck.too_slow,))
         @given(
-            fitted_model=arima_model_strategy(),
+            fitted_model=arima_model_strategy,
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -302,7 +303,7 @@ class TestARIMAModel:
         )
         def test_init_valid(self, fitted_model, X_fitted, rng):
             """Test that ARIMA model initialization works with valid inputs."""
-            TimeSeriesSimulator(fitted_model, X_fitted, rng)
+            TimeSeriesSimulator(fitted_model(), X_fitted, rng)
 
         @settings(suppress_health_check=(HealthCheck.too_slow,))
         @given(
@@ -314,12 +315,13 @@ class TestARIMAModel:
         )
         def test_fitted_model_valid(self, fitted_model, X_fitted, rng):
             """Test that ARIMA model fitted_model property getter and setter work correctly."""
-            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
-            assert simulator.fitted_model == fitted_model
+            model = fitted_model()
+            simulator = TimeSeriesSimulator(model, X_fitted, rng)
+            assert simulator.fitted_model == model
 
         @settings(suppress_health_check=(HealthCheck.too_slow,))
         @given(
-            fitted_model=arima_model_strategy(),
+            fitted_model=arima_model_strategy,
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -327,12 +329,12 @@ class TestARIMAModel:
         )
         def test_X_fitted_valid(self, fitted_model, X_fitted, rng):
             """Test that ARIMA model X_fitted property getter and setter work correctly."""
-            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
+            simulator = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
             assert np.allclose(simulator.X_fitted, X_fitted)
 
         @settings(suppress_health_check=(HealthCheck.too_slow,))
         @given(
-            fitted_model=arima_model_strategy(),
+            fitted_model=arima_model_strategy,
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -340,11 +342,11 @@ class TestARIMAModel:
         )
         def test_rng_valid(self, fitted_model, X_fitted, rng):
             """Test that ARIMA model rng property getter and setter work correctly."""
-            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
+            simulator = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
             assert isinstance(simulator.rng, Generator)
 
         @given(
-            fitted_model=arima_model_strategy(),
+            fitted_model=arima_model_strategy,
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -354,7 +356,7 @@ class TestARIMAModel:
             self, fitted_model, X_fitted, rng
         ):
             """Test that ARIMA model simulation works with valid inputs."""
-            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
+            simulator = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
             simulator.simulate_non_ar_process()
 
         # TODO: even with the same rng object, simulation results are different. Investigate why.
@@ -393,7 +395,7 @@ class TestARIMAModel:
                 TimeSeriesSimulator(fitted_model, X_fitted, rng)
 
         @given(
-            fitted_model=arima_model_strategy(),
+            fitted_model=arima_model_strategy,
             X_fitted=st.none() | integer_array | st.text(),
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -403,13 +405,13 @@ class TestARIMAModel:
             """Test that ARIMA model initialization fails with invalid X_fitted."""
             if not isinstance(X_fitted, np.ndarray):
                 with pytest.raises(TypeError):
-                    TimeSeriesSimulator(fitted_model, X_fitted, rng)
+                    TimeSeriesSimulator(fitted_model(), X_fitted, rng)
 
 
 class TestSARIMAModel:
     class TestPassingCases:
         @given(
-            fitted_model=sarima_model_strategy(),
+            fitted_model=sarima_model_strategy,
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -417,10 +419,10 @@ class TestSARIMAModel:
         )
         def test_init_valid(self, fitted_model, X_fitted, rng):
             """Test that SARIMA model initialization works with valid inputs."""
-            TimeSeriesSimulator(fitted_model, X_fitted, rng)
+            TimeSeriesSimulator(fitted_model(), X_fitted, rng)
 
         @given(
-            fitted_model=sarima_model_strategy(),
+            fitted_model=sarima_model_strategy,
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -428,11 +430,12 @@ class TestSARIMAModel:
         )
         def test_fitted_model_valid(self, fitted_model, X_fitted, rng):
             """Test that SARIMA model fitted_model property getter and setter work correctly."""
-            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
-            assert simulator.fitted_model == fitted_model
+            model = fitted_model()
+            simulator = TimeSeriesSimulator(model, X_fitted, rng)
+            assert simulator.fitted_model == model
 
         @given(
-            fitted_model=sarima_model_strategy(),
+            fitted_model=sarima_model_strategy,
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -440,11 +443,11 @@ class TestSARIMAModel:
         )
         def test_X_fitted_valid(self, fitted_model, X_fitted, rng):
             """Test that SARIMA model X_fitted property getter and setter work correctly."""
-            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
+            simulator = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
             assert np.allclose(simulator.X_fitted, X_fitted)
 
         @given(
-            fitted_model=sarima_model_strategy(),
+            fitted_model=sarima_model_strategy,
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -452,11 +455,11 @@ class TestSARIMAModel:
         )
         def test_rng_valid(self, fitted_model, X_fitted, rng):
             """Test that SARIMA model rng property getter and setter work correctly."""
-            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
+            simulator = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
             assert isinstance(simulator.rng, Generator)
 
         @given(
-            fitted_model=sarima_model_strategy(),
+            fitted_model=sarima_model_strategy,
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -466,7 +469,7 @@ class TestSARIMAModel:
             self, fitted_model, X_fitted, rng
         ):
             """Test that SARIMA model simulation works with valid inputs."""
-            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
+            simulator = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
             simulator.simulate_non_ar_process()
 
         # TODO: even with the same rng object, simulation results are different. Investigate why.
@@ -508,7 +511,7 @@ class TestSARIMAModel:
 class TestVARModel:
     class TestPassingCases:
         @given(
-            fitted_model=var_model_strategy(),
+            fitted_model=var_model_strategy,
             X_fitted=float_array.map(lambda x: np.column_stack([x, x])),
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -516,10 +519,10 @@ class TestVARModel:
         )
         def test_init_valid(self, fitted_model, X_fitted, rng):
             """Test that VAR model initialization works with valid inputs."""
-            TimeSeriesSimulator(fitted_model, X_fitted, rng)
+            TimeSeriesSimulator(fitted_model(), X_fitted, rng)
 
         @given(
-            fitted_model=var_model_strategy(),
+            fitted_model=var_model_strategy,
             X_fitted=float_array.map(lambda x: np.column_stack([x, x])),
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -527,11 +530,12 @@ class TestVARModel:
         )
         def test_fitted_model_valid(self, fitted_model, X_fitted, rng):
             """Test that VAR model fitted_model property getter and setter work correctly."""
-            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
-            assert simulator.fitted_model == fitted_model
+            model = fitted_model()
+            simulator = TimeSeriesSimulator(model, X_fitted, rng)
+            assert simulator.fitted_model == model
 
         @given(
-            fitted_model=var_model_strategy(),
+            fitted_model=var_model_strategy,
             X_fitted=float_array.map(lambda x: np.column_stack([x, x])),
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -539,11 +543,11 @@ class TestVARModel:
         )
         def test_X_fitted_valid(self, fitted_model, X_fitted, rng):
             """Test that VAR model X_fitted property getter and setter work correctly."""
-            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
+            simulator = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
             assert np.allclose(simulator.X_fitted, X_fitted)
 
         @given(
-            fitted_model=var_model_strategy(),
+            fitted_model=var_model_strategy,
             X_fitted=float_array.map(lambda x: np.column_stack([x, x])),
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -551,11 +555,11 @@ class TestVARModel:
         )
         def test_rng_valid(self, fitted_model, X_fitted, rng):
             """Test that VAR model rng property getter and setter work correctly."""
-            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
+            simulator = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
             assert isinstance(simulator.rng, Generator)
 
         @given(
-            fitted_model=var_model_strategy(),
+            fitted_model=var_model_strategy,
             X_fitted=float_array.map(lambda x: np.column_stack([x, x])),
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -566,13 +570,13 @@ class TestVARModel:
         ):
             """Test that VAR model simulation works with valid inputs."""
             print(f"X_fitted.shape = {X_fitted.shape}")
-            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
+            simulator = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
             print(f"simulator.X_fitted.shape = {simulator.X_fitted.shape}")
             print(f"simulator.burnin = {simulator.burnin}")
             simulator.simulate_non_ar_process()
 
         @given(
-            fitted_model=var_model_strategy(),
+            fitted_model=var_model_strategy,
             X_fitted=float_array.map(lambda x: np.column_stack([x, x])),
         )
         def test_simulate_non_ar_same_rng(self, fitted_model, X_fitted):
@@ -580,11 +584,11 @@ class TestVARModel:
             rng_seed = 12345
 
             rng1 = np.random.default_rng(rng_seed)
-            simulator1 = TimeSeriesSimulator(fitted_model, X_fitted, rng1)
+            simulator1 = TimeSeriesSimulator(fitted_model(), X_fitted, rng1)
             simulated_series1 = simulator1.simulate_non_ar_process()
 
             rng2 = np.random.default_rng(rng_seed)
-            simulator2 = TimeSeriesSimulator(fitted_model, X_fitted, rng2)
+            simulator2 = TimeSeriesSimulator(fitted_model(), X_fitted, rng2)
             simulated_series2 = simulator2.simulate_non_ar_process()
 
             print(f"simulated_series1 = {simulated_series1}")
@@ -593,16 +597,16 @@ class TestVARModel:
             assert_arrays_compare(simulated_series1, simulated_series2)
 
         @given(
-            fitted_model=var_model_strategy(),
+            fitted_model=var_model_strategy,
             X_fitted=float_array.map(lambda x: np.column_stack([x, x])),
         )
         def test_simulate_non_ar_different_rng(self, fitted_model, X_fitted):
             """Test that SARIMA model simulation gives same results with same rng."""
             rng = np.random.default_rng()
-            simulator1 = TimeSeriesSimulator(fitted_model, X_fitted, rng)
+            simulator1 = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
             simulated_series1 = simulator1.simulate_non_ar_process()
 
-            simulator2 = TimeSeriesSimulator(fitted_model, X_fitted, rng)
+            simulator2 = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
             simulated_series2 = simulator2.simulate_non_ar_process()
 
             assert_arrays_compare(
@@ -632,7 +636,7 @@ class TestVARModel:
 class TestARCHModel:
     class TestPassingCases:
         @given(
-            fitted_model=arch_model_strategy(),
+            fitted_model=arch_model_strategy,
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -640,10 +644,10 @@ class TestARCHModel:
         )
         def test_init_valid(self, fitted_model, X_fitted, rng):
             """Test that ARCH model initialization works with valid inputs."""
-            TimeSeriesSimulator(fitted_model, X_fitted, rng)
+            TimeSeriesSimulator(fitted_model(), X_fitted, rng)
 
         @given(
-            fitted_model=arch_model_strategy(),
+            fitted_model=arch_model_strategy,
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -651,11 +655,12 @@ class TestARCHModel:
         )
         def test_fitted_model_valid(self, fitted_model, X_fitted, rng):
             """Test that ARCH model fitted_model property getter and setter work correctly."""
-            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
-            assert simulator.fitted_model == fitted_model
+            model = fitted_model()
+            simulator = TimeSeriesSimulator(model, X_fitted, rng)
+            assert simulator.fitted_model == model
 
         @given(
-            fitted_model=arch_model_strategy(),
+            fitted_model=arch_model_strategy,
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -663,11 +668,11 @@ class TestARCHModel:
         )
         def test_X_fitted_valid(self, fitted_model, X_fitted, rng):
             """Test that ARCH model X_fitted property getter and setter work correctly."""
-            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
+            simulator = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
             assert np.allclose(simulator.X_fitted, X_fitted)
 
         @given(
-            fitted_model=arch_model_strategy(),
+            fitted_model=arch_model_strategy,
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -675,11 +680,11 @@ class TestARCHModel:
         )
         def test_rng_valid(self, fitted_model, X_fitted, rng):
             """Test that ARCH model rng property getter and setter work correctly."""
-            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
+            simulator = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
             assert isinstance(simulator.rng, Generator)
 
         @given(
-            fitted_model=arch_model_strategy(),
+            fitted_model=arch_model_strategy,
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -689,7 +694,7 @@ class TestARCHModel:
             self, fitted_model, X_fitted, rng
         ):
             """Test that ARCH model simulation works with valid inputs."""
-            simulator = TimeSeriesSimulator(fitted_model, X_fitted, rng)
+            simulator = TimeSeriesSimulator(fitted_model(), X_fitted, rng)
             simulator.simulate_non_ar_process()
 
         # TODO: even with the same rng object, simulation results are different. Investigate why.

--- a/tests/test_time_series_simulator.py
+++ b/tests/test_time_series_simulator.py
@@ -3,6 +3,7 @@ import pytest
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 from numpy.random import Generator, default_rng
+from skbase.utils.dependencies import _check_soft_dependencies
 from tsbootstrap import TimeSeriesSimulator
 from tsbootstrap.utils.odds_and_ends import assert_arrays_compare
 
@@ -74,6 +75,10 @@ def arch_model_strategy():
     return st.builds(scale_and_fit_arch, float_array_unique)
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 class TestARModel:
     class TestPassingCases:
         @given(
@@ -291,6 +296,10 @@ class TestARModel:
                     TimeSeriesSimulator(fitted_model(), X_fitted, rng)
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 class TestARIMAModel:
     class TestPassingCases:
         @settings(suppress_health_check=(HealthCheck.too_slow,))
@@ -408,6 +417,10 @@ class TestARIMAModel:
                     TimeSeriesSimulator(fitted_model(), X_fitted, rng)
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 class TestSARIMAModel:
     class TestPassingCases:
         @given(
@@ -508,6 +521,10 @@ class TestSARIMAModel:
                 TimeSeriesSimulator(fitted_model, X_fitted, rng)
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("statsmodels", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 class TestVARModel:
     class TestPassingCases:
         @given(
@@ -633,6 +650,10 @@ class TestVARModel:
                 TimeSeriesSimulator(fitted_model, X_fitted, rng)
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("arch", severity="none"),
+    reason="skip test if required soft dependency not available",
+)
 class TestARCHModel:
     class TestPassingCases:
         @given(

--- a/tests/test_time_series_simulator.py
+++ b/tests/test_time_series_simulator.py
@@ -316,7 +316,7 @@ class TestARIMAModel:
 
         @settings(suppress_health_check=(HealthCheck.too_slow,))
         @given(
-            fitted_model=arima_model_strategy(),
+            fitted_model=arima_model_strategy,
             X_fitted=float_array,
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -754,7 +754,7 @@ class TestARCHModel:
                 TimeSeriesSimulator(fitted_model, X_fitted, rng)
 
         @given(
-            fitted_model=arch_model_strategy(),
+            fitted_model=arch_model_strategy,
             X_fitted=st.none() | st.integers() | st.text(),
             rng=st.none()
             | st.integers(min_value=MIN_INT, max_value=MAX_INT)
@@ -763,14 +763,14 @@ class TestARCHModel:
         def test_init_invalid_X_fitted(self, fitted_model, X_fitted, rng):
             """Test that ARCH model initialization fails with invalid X_fitted."""
             with pytest.raises(TypeError):
-                TimeSeriesSimulator(fitted_model, X_fitted, rng)
+                TimeSeriesSimulator(fitted_model(), X_fitted, rng)
 
         @given(
-            fitted_model=arch_model_strategy(),
+            fitted_model=arch_model_strategy,
             X_fitted=float_array,
             rng=st.floats() | st.text(),
         )
         def test_init_invalid_rng(self, fitted_model, X_fitted, rng):
             """Test that ARCH model initialization fails with invalid rng."""
             with pytest.raises(TypeError):
-                TimeSeriesSimulator(fitted_model, X_fitted, rng)
+                TimeSeriesSimulator(fitted_model(), X_fitted, rng)


### PR DESCRIPTION
Finishes consolidation of current dependencies:

* `hmmlearn`, `pyclustering` are isolated and moved to soft dependencies
* tests for `arch`, `statsmodels`, `hmmlearn`, `pyclustering` isolated
* `cython` and `importlib-metadata` are moved to dev dependencies
* upper bounds are introduced for soft and core dependencies, major or minor (depending on first non-zero)