### PR TITLE
maint: remove trigger for `bumpversion.yml` CI element

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   bump-version:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
Removes the trigger (merge to `main`) for the `bumpversion` CI element, but does not remove it.

Temporarily addresses https://github.com/astrogilda/tsbootstrap/issues/42, at least the constant failures, until discussion completes.