### PR TITLE
doc: remove superfluous `pandas` import from `README.md` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,6 @@ Here's a basic example using the Moving Block Bootstrap method:
 
 ```python
 from tsbootstrap import MovingBlockBootstrap, MovingBlockBootstrapConfig
-import pandas as pd
 import numpy as np
 
 np.random.seed(0)


### PR DESCRIPTION
Minor doc fix: remove superfluous `pandas` import from `README.md` example