### PR TITLE
[DOC] remove public docs on configs

### DIFF
--- a/docs/source/base_bootstrap_configs.rst
+++ b/docs/source/base_bootstrap_configs.rst
@@ -1,6 +1,0 @@
-Base Bootstrap Configs
-======================
-
-.. automodule:: tsbootstrap.base_bootstrap_configs
-   :members:
-   :noindex:

--- a/docs/source/block_bootstrap_configs.rst
+++ b/docs/source/block_bootstrap_configs.rst
@@ -1,6 +1,0 @@
-Block Bootstrap Configs
-=======================
-
-.. automodule:: tsbootstrap.block_bootstrap_configs
-   :members:
-   :noindex:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,9 +10,7 @@ Welcome to tsbootstrap's documentation!
    :maxdepth: 2
    :caption: Contents:
 
-   base_bootstrap_configs
    base_bootstrap
-   block_bootstrap_configs
    block_bootstrap
    block_generator
    block_length_sampler


### PR DESCRIPTION
This PR removes the public API reference to the configs, mirroring the intention that they should not be user facing.

Parameters and usage is now sufficiently described in the bootstrap classes imo, and publishing docs on configs would only contribute to user confusion.