### PR TITLE
fix: ensure `check_estimator` runs bootstrap tests for bootstraps

### DIFF
--- a/src/tsbootstrap/tests/test_class_register.py
+++ b/src/tsbootstrap/tests/test_class_register.py
@@ -20,6 +20,7 @@ def get_test_class_registry():
         test class registry
         keys are scitypes, values are test classes TestAll[Scitype]
     """
+    from tsbootstrap.tests.test_all_bootstraps import TestAllBootstraps
     from tsbootstrap.tests.test_all_estimators import TestAllObjects
 
     testclass_dict = dict()
@@ -29,7 +30,7 @@ def get_test_class_registry():
     # more specific base classes
     # these inherit either from BaseEstimator or BaseObject,
     # so also imply estimator and object tests, or only object tests
-    # testclass_dict["bootstrap"] = TestAllBootstraps
+    testclass_dict["bootstrap"] = TestAllBootstraps
 
     return testclass_dict
 

--- a/src/tsbootstrap/tests/test_class_register.py
+++ b/src/tsbootstrap/tests/test_class_register.py
@@ -69,4 +69,15 @@ def get_test_classes_for_obj(obj):
     # we always need to run "object" tests
     test_clss = [testclass_dict["object"]]
 
+    try:
+        obj_scitypes = obj.get_class_tag("object_type")
+        if not isinstance(obj_scitypes, list):
+            obj_scitypes = [obj_scitypes]
+    except Exception:
+        obj_scitypes = []
+
+    for obj_scitype in obj_scitypes:
+        if obj_scitype in testclass_dict:
+            test_clss += [testclass_dict[obj_scitype]]
+
     return test_clss

--- a/src/tsbootstrap/utils/estimator_checks.py
+++ b/src/tsbootstrap/utils/estimator_checks.py
@@ -60,6 +60,14 @@ def check_estimator(
     ------
     if raise_exceptions=True,
     raises any exception produced by the tests directly
+
+    Examples
+    --------
+    >>> from tsbootstrap import MovingBlockBootstrap
+    >>> from tsbootstrap.utils import check_estimator
+    >>>
+    >>> check_estimator(MovingBlockBootstrap, raise_exceptions=True)
+    ...
     """
     msg = (
         "check_estimator is a testing utility for developers, and "


### PR DESCRIPTION
This PR fixes an unreported bug where bootstrap specific tests were not run in `check_estimator`.

It also adds a doctest.