### PR TITLE
mnt: Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,5 @@ jobs:
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: ${{ secrets.PYPI_USER }}
-          password: ${{ secrets.PYPI_PASSWORD }}
+          password: ${{ secrets.PYPI_TOKEN }}
           packages_dir: wheelhouse/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,112 @@
+name: Build wheels and publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build_wheels:
+    name: Build wheels
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Build wheel
+        run: |
+          python -m pip install build
+          python -m build --wheel --sdist --outdir wheelhouse
+
+      - name: Store wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels
+          path: wheelhouse/*
+
+  test_unix_wheels:
+    needs: build_wheels
+    name: Test wheels on ${{ matrix.os }} with ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false  # to not fail all combinations if just one fail
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheels
+          path: wheelhouse
+
+      - name: Display downloaded artifacts
+        run: ls -l wheelhouse
+
+      - name: Get wheel filename
+        run: echo "WHEELNAME=$(ls ./wheelhouse/tsbootstrap-*none-any.whl)" >> $GITHUB_ENV
+
+      - name: Install wheel and extras
+        run: python -m pip install "${{ env.WHEELNAME }}[all_extras,dev]"
+
+      - name: Run tests
+        run: make test_without_datasets
+
+  test_windows_wheels:
+    needs: build_wheels
+    name: Test wheels on ${{ matrix.os }} with ${{ matrix.python-version }}
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false  # to not fail all combinations if just one fail
+      matrix:
+        os: [windows-latest]
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheels
+          path: wheelhouse
+
+      - name: Display downloaded artifacts
+        run: ls -l wheelhouse
+
+      - name: Get wheel filename
+        run: echo "WHEELNAME=$(ls ./wheelhouse/tsbootstrap-*none-any.whl)" >> $env:GITHUB_ENV
+
+      - name: Install wheel and extras
+        run: python -m pip install "${env:WHEELNAME}[all_extras,dev]"
+
+      - name: Run tests  # explicit commands as windows does not support make
+        run: python -m pytest
+
+  upload_wheels:
+    name: Upload wheels to PyPI
+    runs-on: ubuntu-latest
+    needs: [build_wheels,test_unix_wheels,test_windows_wheels]
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheels
+          path: wheelhouse
+
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: ${{ secrets.PYPI_USER }}
+          password: ${{ secrets.PYPI_PASSWORD }}
+          packages_dir: wheelhouse/


### PR DESCRIPTION
This PR adds a release workflow, which builds wheels, tests wheels, and releases on `pypi`, upon making a GitHub release.