### PR TITLE
bug: fix release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
         run: python -m pip install "${{ env.WHEELNAME }}[all_extras,dev]"
 
       - name: Run tests
-        run: make test_without_datasets
+        run: python -m pytest
 
   test_windows_wheels:
     needs: build_wheels


### PR DESCRIPTION
The new release action from #109 had a copy-paste-bug (from `sktime`) - the call the a nonexistent makefile is now replaced with explicit `pytest` call.