### PR TITLE
[ENH] test for init signature conventions, simplified `get_n_bootstraps`

### DIFF
--- a/src/tsbootstrap/base_bootstrap.py
+++ b/src/tsbootstrap/base_bootstrap.py
@@ -267,30 +267,7 @@ class BaseTimeSeriesBootstrap(BaseObject):
         -------
         int : The number of bootstrap instances produced by the bootstrap.
         """
-        X, y = self._check_X_y(X, y)
-
-        return self._get_n_bootstraps(X=X, y=y)
-
-    def _get_n_bootstraps(self, X=None, y=None) -> int:
-        """Returns the number of bootstrap instances produced by the bootstrap.
-
-        Private method to be implemented by derived classes.
-        Input validation is not required in this method.
-
-        Parameters
-        ----------
-        X : 2D array-like of shape (n_timepoints, n_features)
-            The endogenous time series to bootstrap.
-            Dimension 0 is assumed to be the time dimension, ordered
-        y : array-like of shape (n_timepoints, n_features_exog), default=None
-            Exogenous time series to use in bootstrapping.
-
-        Returns
-        -------
-        int : The number of bootstrap instances produced by the bootstrap.
-        """
-        # Default implementation for current classes using config
-        return self.config.n_bootstraps  # type: ignore
+        return self.n_bootstraps
 
 
 class BaseResidualBootstrap(BaseTimeSeriesBootstrap):

--- a/src/tsbootstrap/tests/test_all_bootstraps.py
+++ b/src/tsbootstrap/tests/test_all_bootstraps.py
@@ -47,7 +47,7 @@ class TestAllBootstraps(PackageConfig, BaseFixtureGenerator, QuickTester):
 
         assert len(params_without_default) == 0, (
             f"All parameters of bootstraps must have default values. "
-            Init parameters without default values: {params_without_default}. "
+            "Init parameters without default values: {params_without_default}. "
         )
 
         # test that first parameter is n_bootstraps, with default 10

--- a/src/tsbootstrap/tests/test_all_bootstraps.py
+++ b/src/tsbootstrap/tests/test_all_bootstraps.py
@@ -46,7 +46,7 @@ class TestAllBootstraps(PackageConfig, BaseFixtureGenerator, QuickTester):
         ]
 
         assert len(params_without_default) == 0, (
-            f"All parameters of bootstraps must have default values.
+            f"All parameters of bootstraps must have default values. "
             Init parameters without default values: {params_without_default}. "
         )
 

--- a/src/tsbootstrap/tests/test_all_bootstraps.py
+++ b/src/tsbootstrap/tests/test_all_bootstraps.py
@@ -19,6 +19,24 @@ class TestAllBootstraps(PackageConfig, BaseFixtureGenerator, QuickTester):
     # which object types are generated; None=all, or class (passed to all_objects)
     object_type_filter = "bootstrap"
 
+    def test_class_signature(self, object_class):
+        """Check constraints on class init signature.
+
+        Tests that:
+
+        * the first parameter is n_bootstraps, with default 10
+        * all parameters have defaults
+        """
+        param_names = object_class.get_param_names()
+        param_defaults = object_class.get_param_defaults()
+
+        # test that all parameters have defaults
+        assert all(param in param_defaults for param in param_names)
+
+        # test that first parameter is n_bootstraps, with default 10
+        assert param_names[0] == "n_bootstraps"
+        assert param_defaults["n_bootstraps"] == 10
+
     def test_n_bootstraps(self, object_instance):
         """Tests handling of n_bootstraps parameter."""
         cls_name = object_instance.__class__.__name__

--- a/src/tsbootstrap/tests/test_all_bootstraps.py
+++ b/src/tsbootstrap/tests/test_all_bootstraps.py
@@ -38,7 +38,6 @@ class TestAllBootstraps(PackageConfig, BaseFixtureGenerator, QuickTester):
             if p.name != "self" and p.kind != p.VAR_KEYWORD
         ]
 
-        param_names_in_order = object_class.get_param_names()
         param_defaults = object_class.get_param_defaults()
 
         # test that all parameters have defaults

--- a/src/tsbootstrap/tests/test_all_bootstraps.py
+++ b/src/tsbootstrap/tests/test_all_bootstraps.py
@@ -33,7 +33,7 @@ class TestAllBootstraps(PackageConfig, BaseFixtureGenerator, QuickTester):
 
         # Consider the constructor parameters excluding 'self'
         param_names_in_order = [
-            p
+            p.name
             for p in init_signature.parameters.values()
             if p.name != "self" and p.kind != p.VAR_KEYWORD
         ]
@@ -41,7 +41,14 @@ class TestAllBootstraps(PackageConfig, BaseFixtureGenerator, QuickTester):
         param_defaults = object_class.get_param_defaults()
 
         # test that all parameters have defaults
-        assert all(param in param_defaults for param in param_names_in_order)
+        params_without_default = [
+            param for param in param_names_in_order if param not in param_defaults
+        ]
+
+        assert len(params_without_default) == 0, (
+            f"All parameters of bootstraps must have default values.
+            Init parameters without default values: {params_without_default}. "
+        )
 
         # test that first parameter is n_bootstraps, with default 10
         assert param_names_in_order[0] == "n_bootstraps"

--- a/src/tsbootstrap/tests/test_all_bootstraps.py
+++ b/src/tsbootstrap/tests/test_all_bootstraps.py
@@ -47,7 +47,7 @@ class TestAllBootstraps(PackageConfig, BaseFixtureGenerator, QuickTester):
 
         assert len(params_without_default) == 0, (
             f"All parameters of bootstraps must have default values. "
-            "Init parameters without default values: {params_without_default}. "
+            f"Init parameters without default values: {params_without_default}. "
         )
 
         # test that first parameter is n_bootstraps, with default 10

--- a/src/tsbootstrap/tests/test_all_bootstraps.py
+++ b/src/tsbootstrap/tests/test_all_bootstraps.py
@@ -1,5 +1,7 @@
 """Automated tests based on the skbase test suite template."""
 
+import inspect
+
 import numpy as np
 import pytest
 from skbase.testing import QuickTester
@@ -27,14 +29,23 @@ class TestAllBootstraps(PackageConfig, BaseFixtureGenerator, QuickTester):
         * the first parameter is n_bootstraps, with default 10
         * all parameters have defaults
         """
-        param_names = object_class.get_param_names()
+        init_signature = inspect.signature(object_class.__init__)
+
+        # Consider the constructor parameters excluding 'self'
+        param_names_in_order = [
+            p
+            for p in init_signature.parameters.values()
+            if p.name != "self" and p.kind != p.VAR_KEYWORD
+        ]
+
+        param_names_in_order = object_class.get_param_names()
         param_defaults = object_class.get_param_defaults()
 
         # test that all parameters have defaults
-        assert all(param in param_defaults for param in param_names)
+        assert all(param in param_defaults for param in param_names_in_order)
 
         # test that first parameter is n_bootstraps, with default 10
-        assert param_names[0] == "n_bootstraps"
+        assert param_names_in_order[0] == "n_bootstraps"
         assert param_defaults["n_bootstraps"] == 10
 
     def test_n_bootstraps(self, object_instance):


### PR DESCRIPTION
This PR further cleans up logic around the base interface contract, and adds tests.

* the contract tests now check, for all bootstraps, that:
    * `n_bootstraps` is the first parameter, with default 10
    * all parameters have defaults
* `get_n_bootstraps` now always returns `self.n_bootstraps` instead of reaching into the config, i.e., we change an implementation dependent piece of logic to contract dependent logic that always works, thereby removing the need for implementing this again and again for new bootstrap algorithms.