### PR TITLE
changed macos-latest to macos-13

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -71,7 +71,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -164,7 +164,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false  # to not fail all combinations if just one fail
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:


### PR DESCRIPTION
This PR moves Mac based GHA runners consistently to `macos-13`.

`macos-latest` is failing with `python 3.8` and `3.9` recently, and `macos-14 = macos-latest` has half the memory of `macos-13`.

Solution inspired by https://github.com/sktime/sktime/pull/6328, https://github.com/sktime/skpro/actions/runs/8804926621, and private conversation with @fkiraly 