### PR TITLE
added mp.pool in _generate_samples

### DIFF
--- a/src/tsbootstrap/base_bootstrap.py
+++ b/src/tsbootstrap/base_bootstrap.py
@@ -179,7 +179,7 @@ class BaseTimeSeriesBootstrap(BaseObject):
         if n_jobs == 1:
             # Run bootstrap generation sequentially in the main process
             for _ in range(self.config.n_bootstraps):
-                data, indices = self._generate_samples_single_bootstrap(X, y)
+                indices, data = self._generate_samples_single_bootstrap(X, y)
                 data = np.concatenate(data, axis=0)
                 if return_indices:
                     # hack to fix known issue with non-concatenated index sets
@@ -197,7 +197,7 @@ class BaseTimeSeriesBootstrap(BaseObject):
                     self._generate_samples_single_bootstrap, args
                 )
 
-            for data, indices in results:
+            for indices, data in results:
                 data = np.concatenate(data, axis=0)
                 if return_indices:
                     # hack to fix known issue with non-concatenated index sets

--- a/src/tsbootstrap/block_bootstrap.py
+++ b/src/tsbootstrap/block_bootstrap.py
@@ -124,7 +124,7 @@ class BlockBootstrap(BaseTimeSeriesBootstrap):
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
+        X : array-like of shape (n_timepoints, n_features)
             The input samples.
 
         Returns
@@ -165,7 +165,7 @@ class BlockBootstrap(BaseTimeSeriesBootstrap):
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
+        X : array-like of shape (n_timepoints, n_features)
             The input samples.
 
         Returns
@@ -295,7 +295,7 @@ class BaseBlockBootstrap(BlockBootstrap):
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
+        X : array-like of shape (n_timepoints, n_features)
             The input samples.
 
         Returns

--- a/src/tsbootstrap/tests/test_all_bootstraps.py
+++ b/src/tsbootstrap/tests/test_all_bootstraps.py
@@ -131,9 +131,9 @@ class TestAllBootstraps(PackageConfig, BaseFixtureGenerator, QuickTester):
             )
 
         if not all(bs.ndim == 2 for bs in bss):
+            print([bs.shape for bs in bss])
             raise ValueError(
-                f"{cls_name}.bootstrap yielded arrays with unexpected number of "
-                "dimensions. All bootstrap samples should have 2 dimensions."
+                f"{cls_name}.bootstrap yielded arrays with unexpected number of dimensions. All bootstrap samples should have 2 dimensions."
             )
 
         if not all(bs.shape[0] == n_timepoints for bs in bss):
@@ -218,9 +218,9 @@ class TestAllBootstraps(PackageConfig, BaseFixtureGenerator, QuickTester):
             )
 
         if not all(bs.ndim == 2 for bs in bss):
+            print([bs.shape for bs in bss])
             raise ValueError(
-                f"{cls_name}.bootstrap yielded arrays with unexpected number of "
-                "dimensions. All bootstrap samples should have 2 dimensions."
+                f"{cls_name}.bootstrap yielded arrays with unexpected number of dimensions. All bootstrap samples should have 2 dimensions."
             )
 
         if not all(bs.shape[0] == expected_length for bs in bss):

--- a/src/tsbootstrap/tsfit.py
+++ b/src/tsbootstrap/tsfit.py
@@ -234,11 +234,13 @@ class TSFit(BaseEstimator, RegressorMixin):
                 self.model_params[key] = value
         return self
 
+    '''
     def __repr__(self):
         """
         Official string representation of a TSFit object.
         """
         return f"TSFit(order={self.order}, model_type='{self.model_type}')"
+    '''
 
     def fit(self, X: np.ndarray, y=None) -> TSFit:
         """
@@ -247,7 +249,7 @@ class TSFit(BaseEstimator, RegressorMixin):
         Parameters
         ----------
         X : np.ndarray
-            Input data of shape (n_samples, n_features).
+            Input data of shape (n_timepoints, n_features).
         y : np.ndarray, optional
             Exogenous variables, by default None.
 
@@ -566,7 +568,7 @@ class TSFit(BaseEstimator, RegressorMixin):
         Parameters
         ----------
         X : np.ndarray
-            Input data of shape (n_samples, n_features).
+            Input data of shape (n_timepoints, n_features).
         y : np.ndarray, optional
             Exogenous variables, by default None.
         n_steps : int, optional


### PR DESCRIPTION
# Pull Request Template

## Description

added `n_jobs` (`1` by default) to _generate_samples, leveraging mp.pool to parallelize generation of bootstraps.
closes #149 

## Type of change

Please delete options that are not relevant.

- [x ] New feature (non-breaking change which adds functionality)
- [ x] This change requires a documentation update

## Checklist:

- [x ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
