### PR TITLE
docs: Context7 and DeepWiki indexing (context7.json, llms.txt, badges)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# AGENTS.md
+
+Minimal agent context for tsbootstrap. Full docs: README.md and https://tsbootstrap.readthedocs.io.
+
+## What it is
+Time series bootstrapping. One entry point: `bootstrap(X, *, method=...)` imported from `tsbootstrap`. Typed method specs live in `tsbootstrap.methods`. `diagnose(X).recommended_methods` suggests methods for a series.
+
+## Setup and checks
+- Install: `uv sync --extra dev` (add `--extra examples --extra docs` for notebooks and docs).
+- Tests: `uv run pytest tests/`
+- Lint and format: `uv run ruff check .` and `uv run ruff format .` (both gated in CI; run `uv run pre-commit install` once so commits gate locally).
+- Types: `uv run mypy src/tsbootstrap` and `uv run pyright src/tsbootstrap`.
+
+## Conventions
+- Python 3.10+. Model-based methods (AR/ARIMA/VAR residual, sieve) need the `models` extra; the uncertainty-quantification layer `tsbootstrap.uq` needs the `uq` extra.
+- No em or en dashes in prose. Conventional-commit messages, imperative mood.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@
     <img src="https://img.shields.io/github/issues/astrogilda/tsbootstrap" alt="Issues"/>
     <img src="https://img.shields.io/github/issues-pr/astrogilda/tsbootstrap" alt="Pull Requests"/>
     <img src="https://img.shields.io/github/v/tag/astrogilda/tsbootstrap" alt="Tag"/>
+    <a href="https://deepwiki.com/astrogilda/tsbootstrap"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"/></a>
+    <a href="https://context7.com/astrogilda/tsbootstrap"><img src="https://img.shields.io/badge/Context7-indexed-3b82f6" alt="Context7"/></a>
 </div>
 
 

--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://context7.com/schema/context7.json",
+  "projectTitle": "tsbootstrap",
+  "description": "Time series bootstrapping in Python: one typed bootstrap() entry point across IID, block, residual, sieve, and model-based (AR/ARIMA/VAR) methods, with an uncertainty-quantification layer (EnbPI, adaptive conformal ACI/NexCP, AR forecast intervals) and a diagnose() recommender.",
+  "folders": ["docs/source"],
+  "excludeFolders": ["docs/build", "tests", "htmlcov", "docs/source/_static"],
+  "rules": [
+    "The public entry point is bootstrap(X, *, method=...); typed method specs live in tsbootstrap.methods (IID, MovingBlock, CircularBlock, StationaryBlock, NonOverlappingBlock, TaperedBlock, ResidualBootstrap, SieveAR).",
+    "Block length defaults to automatic Politis-White selection via block_length='auto' (avg_block_length='auto' for StationaryBlock).",
+    "Model-based methods (AR/ARIMA/VAR residual, sieve) need the 'models' extra; the uncertainty-quantification layer tsbootstrap.uq needs the 'uq' extra.",
+    "Call diagnose(X).recommended_methods for a programmatic method recommendation on a series.",
+    "forecast_intervals currently supports AR models only."
+  ]
+}

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,26 @@
+# tsbootstrap
+
+> Time series bootstrapping in Python. One typed entry point, bootstrap(X, *, method=...), spans IID, the block family (moving, circular, stationary, non-overlapping, tapered), model-based residual (AR/ARIMA/VAR) and sieve methods, plus an uncertainty-quantification layer: EnbPI ensembles, adaptive conformal (ACI, NexCP) calibrators, and AR forecast intervals. diagnose(X) returns recommended methods for a series. Install with uv: `uv add tsbootstrap` (core) or `uv add "tsbootstrap[models]"`; the uq layer needs the `uq` extra.
+
+## Guides
+- [Quickstart](https://tsbootstrap.readthedocs.io/en/latest/quickstart.html): the bootstrap() entry point, values(), and the out-of-bag mask.
+- [Methods guide](https://tsbootstrap.readthedocs.io/en/latest/methods_guide.html): every method spec and when to use it.
+- [Adapters guide](https://tsbootstrap.readthedocs.io/en/latest/adapters_guide.html): sktime/skbase estimator classes over the functional core.
+- [Diagnostics guide](https://tsbootstrap.readthedocs.io/en/latest/diagnostics_guide.html): diagnose() and recommended_methods.
+- [Results guide](https://tsbootstrap.readthedocs.io/en/latest/results_guide.html): BootstrapResult, provenance, in-bag and out-of-bag primitives.
+- [Uncertainty quantification guide](https://tsbootstrap.readthedocs.io/en/latest/uq_guide.html): EnbPI, calibrators, forecast intervals, bootstrap_reduce.
+
+## Tutorials
+- [Tutorial gallery](https://tsbootstrap.readthedocs.io/en/latest/tutorials/index.html): executable notebooks covering every method, a which-bootstrap-when decision guide, and the uq layer.
+
+## API reference
+- [bootstrap()](https://tsbootstrap.readthedocs.io/en/latest/api_bootstrap.html): the entry point and bootstrap_reduce.
+- [methods](https://tsbootstrap.readthedocs.io/en/latest/api_methods.html): typed method specs.
+- [diagnostics](https://tsbootstrap.readthedocs.io/en/latest/api_diagnostics.html): diagnose().
+- [results](https://tsbootstrap.readthedocs.io/en/latest/api_results.html): BootstrapResult.
+- [uq](https://tsbootstrap.readthedocs.io/en/latest/api_uq.html): the tsbootstrap.uq surface.
+- [adapters](https://tsbootstrap.readthedocs.io/en/latest/api_adapters.html): estimator classes.
+
+## Source
+- [README](https://github.com/astrogilda/tsbootstrap/blob/main/README.md): overview, install, modules, roadmap.
+- [Repository](https://github.com/astrogilda/tsbootstrap): source, issues, and contribution guide.


### PR DESCRIPTION
Adds agent-documentation indexing surfaces:

- `context7.json` manifest: project title, docs folders, and agent-usage rules (entry point, block-length defaults, extras, diagnose(), AR-only forecast_intervals).
- `llms.txt`: curated index (guides, tutorial gallery, API reference, source) so Context7 / DeepWiki / IDE coding agents ingest the docs efficiently. Conforms to the llmstxt.org spec (H1 + summary blockquote + H2 link lists).
- README badges: Context7 and Ask DeepWiki.

No code or test changes. The one-time context7.com/add-library submission + ownership claim stays a manual step.