### PR TITLE
feat(mcp): read-only MCP server for agent access

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,7 +43,7 @@ jobs:
           python-version: '3.11'
 
       - name: Sync dev environment
-        run: uv sync --extra dev
+        run: uv sync --extra dev --extra mcp
 
       - name: Run ruff check
         run: uv run ruff check .
@@ -65,7 +65,7 @@ jobs:
           python-version: '3.12'
 
       - name: Sync dev environment
-        run: uv sync --extra dev
+        run: uv sync --extra dev --extra mcp
 
       - name: Run mypy
         run: uv run mypy src/tsbootstrap
@@ -99,7 +99,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Sync dev environment
-        run: uv sync --extra dev
+        run: uv sync --extra dev --extra mcp
 
       - name: Show installed dependencies
         run: uv pip list

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -145,7 +145,7 @@ jobs:
           python-version: '3.12'
 
       - name: Sync dev environment
-        run: uv sync --extra dev
+        run: uv sync --extra dev --extra mcp
 
       - name: Run tests with coverage
         env:

--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -1,0 +1,31 @@
+name: Publish to MCP Registry
+
+# Publishes server.json to the official MCP registry once the PyPI package for the
+# tag is available. Authenticates with GitHub OIDC (no stored secrets); the registry
+# verifies ownership via the io.github.astrogilda/* namespace and the mcp-name marker
+# in the package README. The PyPI release itself is handled by release.yml.
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-mcp:
+    name: Publish server.json to the MCP registry
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # required for GitHub OIDC authentication
+      contents: read
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to the MCP registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server to the MCP registry
+        run: ./mcp-publisher publish

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- mcp-name: io.github.astrogilda/tsbootstrap -->
+
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/github/all-contributors/astrogilda/tsbootstrap?color=ee8449&style=flat-square)](#contributors)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
@@ -118,6 +120,27 @@ The conformal pieces (`EnbPIEnsemble` and the calibrators) need the `uq` extra
 [tutorial gallery](https://tsbootstrap.readthedocs.io/en/latest/tutorials/index.html)
 works through every method on real and synthetic data, including a "which bootstrap
 should I use?" decision guide.
+
+### MCP server
+
+`tsbootstrap` ships a read-only [Model Context Protocol](https://modelcontextprotocol.io)
+server so an MCP client (an LLM agent, an IDE) can diagnose a short series and compute a
+bootstrap confidence interval without writing any Python. Run it with no install step:
+
+```sh
+uvx --from "tsbootstrap[mcp]" tsbootstrap-mcp
+```
+
+It speaks the stdio transport and exposes exactly two read-only tools:
+
+- `diagnose_series`: serial-dependence and stationarity diagnostics, a recommended
+  Politis-White block length, and the bootstrap methods the server supports for the series.
+- `bootstrap_confidence_interval`: a percentile confidence interval for the mean, median,
+  std, or variance, using an i.i.d. or block bootstrap.
+
+Both tools accept at most 500 observations and run at most 500 replicates. For larger
+series, model-based methods, or the uncertainty layer, use the library directly in a
+local script.
 
 ### 📦 Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,13 @@ uq = [
     "scikit-learn",
 ]
 
+# Read-only MCP server (src/tsbootstrap/mcp.py). Layers the official MCP Python SDK
+# on top of CORE tsbootstrap only (it does NOT pull the models or uq extras): the two
+# tools are observation-resampling bootstraps, which are pure-numpy.
+mcp = [
+    "mcp>=1.28,<2",
+]
+
 # Compiled acceleration: a numba kernel for the VAR recurrence (replicate-parallel).
 # Pure-numpy is the default; installing this auto-selects the faster kernel.
 accel = [
@@ -131,6 +138,10 @@ dev = [
     "tomlkit",
     "memory-profiler>=0.60.0",  # For performance testing
 ]
+
+[project.scripts]
+# `uvx tsbootstrap-mcp` runs the read-only MCP server over stdio.
+tsbootstrap-mcp = "tsbootstrap.mcp:main"
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/server.json
+++ b/server.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.astrogilda/tsbootstrap",
+  "title": "tsbootstrap",
+  "description": "Read-only time-series bootstrap server: diagnose a series and compute confidence intervals.",
+  "version": "0.2.0",
+  "repository": {
+    "url": "https://github.com/astrogilda/tsbootstrap",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "tsbootstrap",
+      "version": "0.2.0",
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      },
+      "runtimeArguments": [
+        {
+          "type": "named",
+          "name": "--from",
+          "value": "tsbootstrap[mcp]"
+        },
+        {
+          "type": "positional",
+          "valueHint": "entrypoint",
+          "value": "tsbootstrap-mcp"
+        }
+      ]
+    }
+  ]
+}

--- a/src/tsbootstrap/mcp.py
+++ b/src/tsbootstrap/mcp.py
@@ -1,0 +1,450 @@
+"""Read-only Model Context Protocol (MCP) server for tsbootstrap.
+
+This module exposes exactly two read-only tools over stdio so an MCP client (an
+LLM agent, an IDE) can diagnose a short series and compute a bootstrap confidence
+interval without writing any Python:
+
+- ``diagnose_series``: dependence/stationarity diagnostics plus a recommended
+  Politis-White block length and the list of MCP-supported methods.
+- ``bootstrap_confidence_interval``: a percentile confidence interval for a chosen
+  statistic, using one of the observation-resampling bootstrap methods.
+
+Both tools are bounded: at most 500 observations and at most 500 replicates. For
+larger series, model-based methods (ARIMA/VAR/sieve), or the uncertainty layer,
+use the tsbootstrap library directly in a local script.
+
+The server runs over the stdio transport by default. In stdio mode the protocol
+owns ``stdout``; this module therefore never writes to ``stdout`` (diagnostics go
+to ``stderr``). The ``mcp`` package is only imported when the server actually
+starts, so importing this module on a core-only install does not hard-require it.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING, Annotated, Any, Literal
+
+import numpy as np
+from pydantic import Field
+
+from tsbootstrap.api import bootstrap_reduce
+from tsbootstrap.block.pwsd import optimal_block_length
+from tsbootstrap.diagnostics import diagnose
+from tsbootstrap.errors import TSBootstrapError
+from tsbootstrap.methods import (
+    IID,
+    BaseMethodSpec,
+    CircularBlock,
+    MovingBlock,
+    NonOverlappingBlock,
+    StationaryBlock,
+    TaperedBlock,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - import only for type checkers
+    from mcp.server.fastmcp import FastMCP
+
+# --------------------------------------------------------------------------- #
+# Hard caps and the allowed enumerations. These are the public contract for the
+# two tools and are echoed back in every structured error.
+# --------------------------------------------------------------------------- #
+MAX_SERIES_LENGTH = 500
+MAX_N_BOOTSTRAPS = 500
+DEFAULT_N_BOOTSTRAPS = 200
+
+#: Method names this server accepts (the observation-resampling family only).
+MethodName = Literal[
+    "IID",
+    "MovingBlock",
+    "CircularBlock",
+    "StationaryBlock",
+    "NonOverlappingBlock",
+    "TaperedBlock",
+]
+#: Statistics this server can compute over the replicates.
+StatisticName = Literal["mean", "median", "std", "variance"]
+
+VALID_METHOD_NAMES: tuple[str, ...] = (
+    "IID",
+    "MovingBlock",
+    "CircularBlock",
+    "StationaryBlock",
+    "NonOverlappingBlock",
+    "TaperedBlock",
+)
+VALID_STATISTIC_NAMES: tuple[str, ...] = ("mean", "median", "std", "variance")
+
+_INSTALL_HINT = "install tsbootstrap[models] and use the library directly"
+
+# Map each diagnose() recommendation string to the concrete method name this
+# server supports, so we can split the recommendations into in-scope methods and
+# the model-based ones that require a local install.
+_SUPPORTED_BY_RECOMMENDATION: dict[str, str] = {
+    "IID": "IID",
+    "MovingBlock": "MovingBlock",
+    "CircularBlock": "CircularBlock",
+    "StationaryBlock": "StationaryBlock",
+    "NonOverlappingBlock": "NonOverlappingBlock",
+    "TaperedBlock": "TaperedBlock",
+}
+
+# numpy reducers for the four supported statistics.
+_STATISTIC_FUNCS: dict[str, Any] = {
+    "mean": np.mean,
+    "median": np.median,
+    "std": np.std,
+    "variance": np.var,
+}
+
+
+class _ToolError(Exception):
+    """Internal signal that a tool input was invalid; carries a structured payload."""
+
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.payload = payload
+        super().__init__(str(payload))
+
+
+def _error(message: str, **extra: Any) -> dict[str, Any]:
+    """Build the structured error payload returned by both tools."""
+    payload: dict[str, Any] = {
+        "error": message,
+        "valid_method_names": list(VALID_METHOD_NAMES),
+        "valid_statistic_names": list(VALID_STATISTIC_NAMES),
+        "max_series_length": MAX_SERIES_LENGTH,
+        "max_n_bootstraps": MAX_N_BOOTSTRAPS,
+    }
+    payload.update(extra)
+    return payload
+
+
+def _coerce_series(series: list[float]) -> np.ndarray:
+    """Validate and convert the input series, enforcing the 500-observation cap."""
+    if not isinstance(series, (list, tuple)):
+        raise _ToolError(_error("series must be a list of numbers"))
+    if len(series) > MAX_SERIES_LENGTH:
+        raise _ToolError(
+            _error(
+                f"series has {len(series)} observations, which exceeds the cap of "
+                f"{MAX_SERIES_LENGTH}; for larger series use the tsbootstrap library directly",
+                series_length=len(series),
+            )
+        )
+    if len(series) < 2:
+        raise _ToolError(
+            _error("series must have at least 2 observations", series_length=len(series))
+        )
+    try:
+        arr = np.asarray(series, dtype=np.float64)
+    except (ValueError, TypeError) as exc:
+        raise _ToolError(_error(f"series must be numeric: {exc}")) from exc
+    if arr.ndim != 1:
+        raise _ToolError(_error("series must be one-dimensional"))
+    if not np.all(np.isfinite(arr)):
+        raise _ToolError(_error("series must contain only finite numbers (no NaN or inf)"))
+    return arr
+
+
+def _build_method_spec(method_name: str, block_length: int | None) -> BaseMethodSpec:
+    """Build a method spec, routing block_length to the right field per method.
+
+    ``block_length`` is routed to ``block_length`` for the block methods that take
+    it, to ``avg_block_length`` for ``StationaryBlock``, and ignored for ``IID``.
+    When ``block_length`` is ``None`` the field is omitted so the library uses its
+    ``"auto"`` (Politis-White) default.
+    """
+    if method_name == "IID":
+        return IID()
+    if method_name == "StationaryBlock":
+        if block_length is None:
+            return StationaryBlock()
+        return StationaryBlock(avg_block_length=block_length)
+    block_classes: dict[str, type[BaseMethodSpec]] = {
+        "MovingBlock": MovingBlock,
+        "CircularBlock": CircularBlock,
+        "NonOverlappingBlock": NonOverlappingBlock,
+        "TaperedBlock": TaperedBlock,
+    }
+    cls = block_classes[method_name]
+    if block_length is None:
+        return cls()
+    return cls(block_length=block_length)  # type: ignore[call-arg]
+
+
+def _validate_ci_inputs(
+    series: list[float],
+    method_name: str,
+    statistic: str,
+    block_length: int | None,
+    n_bootstraps: int,
+    confidence_level: float,
+) -> dict[str, Any] | tuple[np.ndarray, BaseMethodSpec, Any]:
+    """Validate every input; return a structured-error dict or (arr, spec, reducer).
+
+    All input checks live here (outside the bootstrap call) so the only ``try``
+    in the tool body wraps the library call itself.
+    """
+    try:
+        arr = _coerce_series(series)
+    except _ToolError as exc:
+        return exc.payload
+
+    if method_name not in VALID_METHOD_NAMES:
+        return _error(f"unknown method_name {method_name!r}")
+    if statistic not in VALID_STATISTIC_NAMES:
+        return _error(f"unknown statistic {statistic!r}")
+    if not isinstance(n_bootstraps, int) or isinstance(n_bootstraps, bool) or n_bootstraps < 1:
+        return _error("n_bootstraps must be an integer >= 1")
+    if n_bootstraps > MAX_N_BOOTSTRAPS:
+        return _error(
+            f"n_bootstraps {n_bootstraps} exceeds the cap of {MAX_N_BOOTSTRAPS}",
+            n_bootstraps=n_bootstraps,
+        )
+    if not 0.0 < confidence_level < 1.0:
+        return _error("confidence_level must be strictly between 0 and 1")
+    if block_length is not None and (
+        not isinstance(block_length, int) or isinstance(block_length, bool) or block_length < 1
+    ):
+        return _error("block_length must be a positive integer or null")
+
+    spec = _build_method_spec(method_name, block_length)
+    reducer = _STATISTIC_FUNCS[statistic]
+    return arr, spec, reducer
+
+
+# Note: the 500-observation cap is enforced inside the tool body (see
+# _coerce_series) so an oversized input returns the documented STRUCTURED error
+# rather than a raw schema-validation failure. The cap is documented here for the
+# client's benefit.
+_SeriesField = Annotated[
+    list[float],
+    Field(
+        description=(
+            "The univariate time series as a flat list of numbers, in time order. "
+            f"At most {MAX_SERIES_LENGTH} observations; a longer list returns a "
+            "structured error."
+        ),
+        examples=[[1.0, 1.2, 0.9, 1.4, 1.1, 1.6, 1.3, 1.8]],
+    ),
+]
+
+
+def diagnose_series(series: _SeriesField) -> dict[str, Any]:
+    """Diagnose a short univariate series and recommend bootstrap methods.
+
+    Read-only. Accepts at most 500 observations; a longer series returns a
+    structured error. For larger series, model-based methods, or the uq layer,
+    use the tsbootstrap library directly in a local script.
+
+    Returns
+    -------
+    dict
+        ``stats`` ({n_obs, lag1_autocorr, is_dependent, is_stationary}),
+        ``recommended_block_length`` (int, Politis-White stationary length),
+        ``mcp_supported_methods`` (list of method names this server can run),
+        ``requires_local_execution`` (model-based recommendations with an install
+        note), and ``notes`` (advisory strings from the diagnosis).
+    """
+    try:
+        arr = _coerce_series(series)
+    except _ToolError as exc:
+        return exc.payload
+
+    diag = diagnose(arr)
+    recommended_block_length = int(optimal_block_length(arr, kind="stationary"))
+
+    mcp_supported_methods: list[str] = []
+    requires_local_execution: list[dict[str, str]] = []
+    for rec in diag.recommended_methods:
+        supported = _SUPPORTED_BY_RECOMMENDATION.get(rec)
+        if supported is not None:
+            if supported not in mcp_supported_methods:
+                mcp_supported_methods.append(supported)
+        else:
+            requires_local_execution.append({"method": rec, "note": _INSTALL_HINT})
+
+    return {
+        "stats": {
+            "n_obs": int(diag.n_obs),
+            "lag1_autocorr": float(diag.lag1_autocorr),
+            "is_dependent": bool(diag.dependent),
+            "is_stationary": bool(not diag.nonstationary),
+        },
+        "recommended_block_length": recommended_block_length,
+        "mcp_supported_methods": mcp_supported_methods,
+        "requires_local_execution": requires_local_execution,
+        "notes": list(diag.notes),
+    }
+
+
+def bootstrap_confidence_interval(
+    series: _SeriesField,
+    method_name: Annotated[
+        MethodName,
+        Field(
+            description=(
+                "Which observation-resampling bootstrap to use. One of: "
+                "IID, MovingBlock, CircularBlock, StationaryBlock, "
+                "NonOverlappingBlock, TaperedBlock."
+            ),
+            examples=["MovingBlock"],
+        ),
+    ],
+    statistic: Annotated[
+        StatisticName,
+        Field(
+            description="The statistic to bootstrap: mean, median, std, or variance.",
+            examples=["mean"],
+        ),
+    ],
+    random_state: Annotated[
+        int,
+        Field(
+            description=(
+                "Required seed for reproducibility; the same seed and inputs give "
+                "the same interval."
+            ),
+            examples=[42],
+        ),
+    ],
+    block_length: Annotated[
+        int | None,
+        Field(
+            description=(
+                "Block length for the block methods (routed to avg_block_length for "
+                "StationaryBlock, ignored for IID). When null, the library picks the "
+                "Politis-White automatic length."
+            ),
+            examples=[None, 8],
+        ),
+    ] = None,
+    n_bootstraps: Annotated[
+        int,
+        Field(
+            description=(
+                f"Number of bootstrap replicates (at most {MAX_N_BOOTSTRAPS}; default "
+                f"{DEFAULT_N_BOOTSTRAPS}). A larger value returns a structured error."
+            ),
+            examples=[200],
+        ),
+    ] = DEFAULT_N_BOOTSTRAPS,
+    confidence_level: Annotated[
+        float,
+        Field(
+            description="Two-sided confidence level for the percentile interval, in (0, 1).",
+            examples=[0.95],
+        ),
+    ] = 0.95,
+) -> dict[str, Any]:
+    """Bootstrap a percentile confidence interval for a statistic of a series.
+
+    Read-only. Accepts at most 500 observations and at most 500 replicates; longer
+    inputs return a structured error. ``random_state`` is required for
+    reproducibility. For larger series, model-based methods, or the uq layer, use
+    the tsbootstrap library directly in a local script.
+
+    Returns
+    -------
+    dict
+        ``point_estimate`` (the statistic on the original series),
+        ``standard_error`` (std of the statistic across replicates),
+        ``ci_lower`` / ``ci_upper`` (percentile interval bounds), and the echoed
+        ``confidence_level``, ``n_bootstraps``, ``method``, and ``random_state``.
+    """
+    validated = _validate_ci_inputs(
+        series, method_name, statistic, block_length, n_bootstraps, confidence_level
+    )
+    if isinstance(validated, dict):  # a structured error
+        return validated
+    arr, spec, reducer = validated
+
+    try:
+        result = bootstrap_reduce(
+            arr,
+            method=spec,
+            statistic=lambda values, _indices: float(reducer(values)),
+            n_bootstraps=n_bootstraps,
+            random_state=random_state,
+        )
+    except (ValueError, TypeError, TSBootstrapError) as exc:
+        return _error(f"bootstrap failed: {exc}")
+
+    if result.statistics is None:  # pragma: no cover - block methods do not fail preparation
+        return _error(f"bootstrap run failed: {result.failure_reason}")
+
+    replicate_stats = np.asarray(result.statistics, dtype=np.float64).reshape(-1)
+    alpha = 1.0 - confidence_level
+    lower_q = 100.0 * (alpha / 2.0)
+    upper_q = 100.0 * (1.0 - alpha / 2.0)
+
+    return {
+        "point_estimate": float(reducer(arr)),
+        "standard_error": float(np.std(replicate_stats, ddof=0)),
+        "ci_lower": float(np.percentile(replicate_stats, lower_q)),
+        "ci_upper": float(np.percentile(replicate_stats, upper_q)),
+        "confidence_level": float(confidence_level),
+        "n_bootstraps": int(n_bootstraps),
+        "method": method_name,
+        "random_state": int(random_state),
+    }
+
+
+def build_server() -> FastMCP:
+    """Construct the FastMCP server and register the two read-only tools.
+
+    Importing ``mcp`` is deferred to here so importing this module on a core-only
+    install does not hard-require the ``mcp`` package.
+    """
+    try:
+        from mcp.server.fastmcp import FastMCP
+        from mcp.types import ToolAnnotations
+    except ImportError as exc:  # pragma: no cover - exercised only without the extra
+        raise ImportError(
+            "the MCP server requires the 'mcp' package; install it with "
+            "'pip install tsbootstrap[mcp]' (or 'uvx tsbootstrap-mcp')"
+        ) from exc
+
+    server = FastMCP(name="tsbootstrap")
+    read_only = ToolAnnotations(readOnlyHint=True)
+
+    server.tool(
+        name="diagnose_series",
+        description=(
+            "Read-only. Diagnose a short univariate time series: serial dependence, "
+            "stationarity, a recommended Politis-White block length, and which bootstrap "
+            "methods this server supports for it. Accepts at most 500 observations. For "
+            "larger series, model-based methods, or the uq layer, use the tsbootstrap "
+            "library directly in a local script."
+        ),
+        annotations=read_only,
+    )(diagnose_series)
+
+    server.tool(
+        name="bootstrap_confidence_interval",
+        description=(
+            "Read-only. Compute a percentile confidence interval for a statistic "
+            "(mean/median/std/variance) of a short series using a block or i.i.d. "
+            "bootstrap. Accepts at most 500 observations and at most 500 replicates; "
+            "random_state is required for reproducibility. For larger series, "
+            "model-based methods, or the uq layer, use the tsbootstrap library "
+            "directly in a local script."
+        ),
+        annotations=read_only,
+    )(bootstrap_confidence_interval)
+
+    return server
+
+
+def main() -> None:
+    """Console-script entry point: run the server over stdio.
+
+    Never writes to stdout (the stdio transport owns it); the startup banner goes
+    to stderr.
+    """
+    print("Starting tsbootstrap MCP server (stdio).", file=sys.stderr)
+    server = build_server()
+    server.run()
+
+
+if __name__ == "__main__":  # pragma: no cover - module run as a script
+    main()

--- a/src/tsbootstrap/mcp.py
+++ b/src/tsbootstrap/mcp.py
@@ -435,7 +435,7 @@ def build_server() -> FastMCP:
     return server
 
 
-def main() -> None:
+def main() -> None:  # pragma: no cover - entry point runs the blocking stdio server
     """Console-script entry point: run the server over stdio.
 
     Never writes to stdout (the stdio transport owns it); the startup banner goes

--- a/tests/unit/test_mcp.py
+++ b/tests/unit/test_mcp.py
@@ -11,7 +11,9 @@ import asyncio
 import numpy as np
 import pytest
 
-from tsbootstrap import mcp
+pytest.importorskip("mcp")  # the MCP SDK ships only with the [mcp] extra
+
+from tsbootstrap import mcp  # noqa: E402
 
 
 def _series(n: int = 60, seed: int = 0) -> list[float]:

--- a/tests/unit/test_mcp.py
+++ b/tests/unit/test_mcp.py
@@ -1,0 +1,184 @@
+"""Tests for the read-only MCP server (src/tsbootstrap/mcp.py).
+
+These exercise the tool functions directly (the FastMCP wrapper is a thin layer
+over them) plus the server construction and tool enumeration.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import numpy as np
+import pytest
+
+from tsbootstrap import mcp
+
+
+def _series(n: int = 60, seed: int = 0) -> list[float]:
+    rng = np.random.default_rng(seed)
+    # AR(1)-ish series: stationary but serially dependent.
+    x = np.zeros(n)
+    for i in range(1, n):
+        x[i] = 0.5 * x[i - 1] + rng.standard_normal()
+    return [float(v) for v in x]
+
+
+# --------------------------------------------------------------------------- #
+# Server construction + tool enumeration.
+# --------------------------------------------------------------------------- #
+def test_server_builds_and_enumerates_both_tools() -> None:
+    server = mcp.build_server()
+    tools = asyncio.run(server.list_tools())
+    names = {t.name for t in tools}
+    assert names == {"diagnose_series", "bootstrap_confidence_interval"}
+    for tool in tools:
+        assert tool.annotations is not None
+        assert tool.annotations.readOnlyHint is True
+        assert tool.description and "read-only" in tool.description.lower()
+        # every input field carries a description
+        props = tool.inputSchema["properties"]
+        assert props
+        for schema in props.values():
+            assert schema.get("description")
+
+
+# --------------------------------------------------------------------------- #
+# diagnose_series.
+# --------------------------------------------------------------------------- #
+def test_diagnose_series_returns_normalized_fields() -> None:
+    out = mcp.diagnose_series(_series())
+    assert set(out) == {
+        "stats",
+        "recommended_block_length",
+        "mcp_supported_methods",
+        "requires_local_execution",
+        "notes",
+    }
+    stats = out["stats"]
+    assert set(stats) == {"n_obs", "lag1_autocorr", "is_dependent", "is_stationary"}
+    assert stats["n_obs"] == 60
+    assert isinstance(stats["lag1_autocorr"], float)
+    assert isinstance(stats["is_dependent"], bool)
+    assert isinstance(stats["is_stationary"], bool)
+    assert isinstance(out["recommended_block_length"], int)
+    assert out["recommended_block_length"] >= 1
+    for m in out["mcp_supported_methods"]:
+        assert m in mcp.VALID_METHOD_NAMES
+
+
+def test_diagnose_series_flags_model_based_recommendations_for_local_execution() -> None:
+    # A random walk looks non-stationary, so diagnose recommends ARIMA/Sieve.
+    rng = np.random.default_rng(1)
+    walk = list(np.cumsum(rng.standard_normal(80)))
+    out = mcp.diagnose_series(walk)
+    assert out["requires_local_execution"], "expected model-based recommendations"
+    for entry in out["requires_local_execution"]:
+        assert set(entry) == {"method", "note"}
+        assert "tsbootstrap[models]" in entry["note"]
+
+
+def test_diagnose_series_rejects_too_long() -> None:
+    out = mcp.diagnose_series([0.0] * (mcp.MAX_SERIES_LENGTH + 1))
+    assert "error" in out
+    assert str(mcp.MAX_SERIES_LENGTH) in out["error"]
+    assert out["max_series_length"] == mcp.MAX_SERIES_LENGTH
+
+
+# --------------------------------------------------------------------------- #
+# bootstrap_confidence_interval.
+# --------------------------------------------------------------------------- #
+def test_ci_returns_point_se_and_interval() -> None:
+    out = mcp.bootstrap_confidence_interval(_series(), "MovingBlock", "mean", random_state=7)
+    assert set(out) == {
+        "point_estimate",
+        "standard_error",
+        "ci_lower",
+        "ci_upper",
+        "confidence_level",
+        "n_bootstraps",
+        "method",
+        "random_state",
+    }
+    assert out["ci_lower"] <= out["ci_upper"]
+    assert out["standard_error"] >= 0.0
+    assert out["confidence_level"] == 0.95
+    assert out["n_bootstraps"] == mcp.DEFAULT_N_BOOTSTRAPS
+    assert out["method"] == "MovingBlock"
+    assert out["random_state"] == 7
+    expected = float(np.mean(np.asarray(_series(), dtype=float)))
+    assert out["point_estimate"] == pytest.approx(expected)
+
+
+def test_ci_is_reproducible_for_fixed_random_state() -> None:
+    a = mcp.bootstrap_confidence_interval(_series(), "CircularBlock", "std", random_state=99)
+    b = mcp.bootstrap_confidence_interval(_series(), "CircularBlock", "std", random_state=99)
+    assert a == b
+
+
+@pytest.mark.parametrize("method", list(mcp.VALID_METHOD_NAMES))
+def test_ci_runs_for_every_supported_method(method: str) -> None:
+    out = mcp.bootstrap_confidence_interval(_series(), method, "mean", random_state=3)
+    assert "point_estimate" in out
+
+
+@pytest.mark.parametrize("stat", list(mcp.VALID_STATISTIC_NAMES))
+def test_ci_runs_for_every_supported_statistic(stat: str) -> None:
+    out = mcp.bootstrap_confidence_interval(_series(), "IID", stat, random_state=3)
+    assert "point_estimate" in out
+
+
+def test_ci_stationary_routes_block_length_to_avg_block_length() -> None:
+    out = mcp.bootstrap_confidence_interval(
+        _series(), "StationaryBlock", "mean", random_state=5, block_length=6
+    )
+    assert "point_estimate" in out
+
+
+def test_ci_block_length_none_uses_auto() -> None:
+    out = mcp.bootstrap_confidence_interval(
+        _series(), "MovingBlock", "mean", random_state=5, block_length=None
+    )
+    assert "point_estimate" in out
+
+
+# --------------------------------------------------------------------------- #
+# Structured error contract.
+# --------------------------------------------------------------------------- #
+def test_ci_rejects_series_too_long() -> None:
+    out = mcp.bootstrap_confidence_interval(
+        [0.0] * (mcp.MAX_SERIES_LENGTH + 1), "IID", "mean", random_state=1
+    )
+    assert "error" in out
+    assert out["valid_method_names"] == list(mcp.VALID_METHOD_NAMES)
+    assert out["valid_statistic_names"] == list(mcp.VALID_STATISTIC_NAMES)
+    assert str(mcp.MAX_SERIES_LENGTH) in out["error"]
+
+
+def test_ci_rejects_too_many_bootstraps() -> None:
+    out = mcp.bootstrap_confidence_interval(
+        _series(), "IID", "mean", random_state=1, n_bootstraps=mcp.MAX_N_BOOTSTRAPS + 1
+    )
+    assert "error" in out
+    assert str(mcp.MAX_N_BOOTSTRAPS) in out["error"]
+    assert out["valid_method_names"] == list(mcp.VALID_METHOD_NAMES)
+
+
+def test_ci_rejects_unknown_method() -> None:
+    out = mcp.bootstrap_confidence_interval(_series(), "NotAMethod", "mean", random_state=1)
+    assert "error" in out
+    assert out["valid_method_names"] == list(mcp.VALID_METHOD_NAMES)
+    assert out["valid_statistic_names"] == list(mcp.VALID_STATISTIC_NAMES)
+
+
+def test_ci_rejects_unknown_statistic() -> None:
+    out = mcp.bootstrap_confidence_interval(_series(), "IID", "geometric_mean", random_state=1)
+    assert "error" in out
+    assert out["valid_statistic_names"] == list(mcp.VALID_STATISTIC_NAMES)
+    assert out["valid_method_names"] == list(mcp.VALID_METHOD_NAMES)
+
+
+def test_ci_rejects_bad_confidence_level() -> None:
+    out = mcp.bootstrap_confidence_interval(
+        _series(), "IID", "mean", random_state=1, confidence_level=1.5
+    )
+    assert "error" in out

--- a/uv.lock
+++ b/uv.lock
@@ -810,6 +810,50 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "49.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d3/4a83af35d65e3fad632c926fad684c193ea4398569ccb0bbbc7fe8f5dc9a/cryptography-49.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc1e275c2f1d97b1a6450b8b0ea3ebfa6e087a611c2b26cb2404d48588abab7b", size = 3993685, upload-time = "2026-06-12T20:02:14.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a7/f9dac0ab7f80368c56993a7bf638ef9935f825c91902798481fac0898138/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c83782480a4a9da4d0feb51950131ba32e12e70813848b3343f6e18c28a66838", size = 4676239, upload-time = "2026-06-12T20:02:28.793Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/70/2ba3769dd0ae167e2f33dfa9592d45db6ff9a61d62ca1a5b3d1bdd09068f/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:b39efa323140595abd3ecca8529d321ae50f55f3aa3ba9cc81ea56a6011953d5", size = 4715584, upload-time = "2026-06-12T20:01:27.495Z" },
+    { url = "https://files.pythonhosted.org/packages/94/64/2923570ac1c0bd3a737aa366ac3abbbbde273042308b8cde95e2364a6e6a/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:b47db11c2c3525083296069b98ac5221907455e989ae0c2e3008bde851921615", size = 4675885, upload-time = "2026-06-12T20:01:55.49Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/f8/614dc7e051418cfe53d55173c1e24c6b0085e89996fe90508c2fdf769aef/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:084ef1af862eb07ec46d25f68689f2102a9fc0e05ce7b80f14f5fe51e4eef0f6", size = 4715449, upload-time = "2026-06-12T20:02:05.469Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/50/a9caea39ad19c431c1a3f8a31114df65b260cdfe67786b6c7e7c040c4c44/cryptography-49.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:be9fcb48a55f023493482827d4f459bd263cc20efde64f204b97c123201850c6", size = 3783731, upload-time = "2026-06-12T20:02:43.319Z" },
+]
+
+[[package]]
 name = "cycler"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1037,6 +1081,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
 ]
 
 [[package]]
@@ -2157,6 +2210,31 @@ wheels = [
 ]
 
 [[package]]
+name = "mcp"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/ee/94c6c50ffc5b5cf4737052275d11b57367f32d1a8516e31dcd60591b3916/mcp-1.28.0.tar.gz", hash = "sha256:559d3f9943674cafbe5744c5d3794f3237e8b47f9bbc58e20c0fad680d8487c2", size = 636040, upload-time = "2026-06-16T21:37:17.996Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/e1/4c1dc1fbb688641a712d34650c3d58bbbdcb314ddb75bc5817bbf33515a4/mcp-1.28.0-py3-none-any.whl", hash = "sha256:9c1e7cf3a9125557e418ecd4fed8e9adddce81b0dfdae4d6601d700f5beb71a4", size = 221959, upload-time = "2026-06-16T21:37:16.579Z" },
+]
+
+[[package]]
 name = "mdit-py-plugins"
 version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3097,6 +3175,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
+]
+
+[[package]]
 name = "pydata-sphinx-theme"
 version = "0.17.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3144,6 +3236,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -3290,12 +3399,30 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
 name = "python-json-logger"
 version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f7/ff/3cc9165fd44106973cd7ac9facb674a65ed853494592541d339bdc9a30eb/python_json_logger-4.1.0.tar.gz", hash = "sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195", size = 17573, upload-time = "2026-03-29T04:39:56.805Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/be/0631a861af4d1c875f096c07d34e9a63639560a717130e7a87cbc82b7e3f/python_json_logger-4.1.0-py3-none-any.whl", hash = "sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2", size = 15021, upload-time = "2026-03-29T04:39:55.266Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
 ]
 
 [[package]]
@@ -4233,6 +4360,19 @@ wheels = [
 ]
 
 [[package]]
+name = "sse-starlette"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/1b/bc9e3e7a72dcdad7dc7888758f5d00f56f8909ed5cfdff822bd72bb4c520/sse_starlette-3.4.5.tar.gz", hash = "sha256:83072538bc211a2f68b7b0422226c4af3e9b62e106e07034664b832ca019842a", size = 35249, upload-time = "2026-06-20T17:36:58.322Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/75/c88d3f5dafd59c791da1ce27650d30bf5b70cbf1cbf01cd00e5f9e360915/sse_starlette-3.4.5-py3-none-any.whl", hash = "sha256:e71bad53323f65573c3864a6c3bd0c1eb6e5f092b2e48082b0c35927d19ca296", size = 16518, upload-time = "2026-06-20T17:36:56.729Z" },
+]
+
+[[package]]
 name = "stack-data"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -4244,6 +4384,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]
@@ -4545,6 +4698,9 @@ examples = [
     { name = "sktime" },
     { name = "statsmodels" },
 ]
+mcp = [
+    { name = "mcp" },
+]
 models = [
     { name = "statsmodels" },
 ]
@@ -4573,6 +4729,7 @@ requires-dist = [
     { name = "jupyter", marker = "extra == 'examples'" },
     { name = "line-profiler", marker = "extra == 'profile'" },
     { name = "matplotlib", marker = "extra == 'examples'" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.28,<2" },
     { name = "memory-profiler", marker = "extra == 'dev'", specifier = ">=0.60.0" },
     { name = "memory-profiler", marker = "extra == 'profile'" },
     { name = "mutmut", marker = "extra == 'dev'", specifier = ">=3" },
@@ -4624,7 +4781,7 @@ requires-dist = [
     { name = "tsbootstrap", extras = ["models", "uq"], marker = "extra == 'examples'" },
     { name = "typos", marker = "extra == 'dev'" },
 ]
-provides-extras = ["models", "uq", "accel", "examples", "profile", "docs", "dev"]
+provides-extras = ["models", "uq", "mcp", "accel", "examples", "profile", "docs", "dev"]
 
 [[package]]
 name = "typeshed-client"
@@ -4724,6 +4881,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.49.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/fa18009dea8469069cca78a4e877a008ab78f08b064bfc9ab891579077ff/uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3", size = 91284, upload-time = "2026-06-03T22:01:30.448Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl", hash = "sha256:ba3d14c3ee7e41c6c654c46c9eb489d33213cdd30aa1696eab1374337c13f68f", size = 71376, upload-time = "2026-06-03T22:01:29.037Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds a read-only MCP server so coding agents can use tsbootstrap over the Model Context Protocol. Tool surface locked by a multi-turn cross-family design debate (transcript kept internally); deliberately minimal.

Two read-only tools:
- `diagnose_series(series)`: normalized diagnose() output (stats, recommended_block_length via Politis-White, executor-compatible methods, and a 'use the library directly' list for model-based methods).
- `bootstrap_confidence_interval(series, method_name, statistic, random_state, ...)`: point estimate + standard error + percentile CI via bootstrap_reduce. random_state required for reproducibility; block_length routed per method; 500-obs / 500-replicate caps with structured errors.

Packaging: `[mcp]` extra (core deps only, no models/uq), `uvx tsbootstrap-mcp`, stdio. server.json + README mcp-name marker + an OIDC release workflow to publish to the MCP registry. 23 new tests.

Gates green locally: ruff, ruff format, mypy, pyright, 242 pytest, pre-commit.