### PR TITLE
ci: per-file coverage gate, codecov informational, OIDC publishing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -125,6 +125,45 @@ jobs:
           fail_ci_if_error: false
           verbose: true
 
+  # Per-file coverage gate (blocking). Unlike codecov.io (which is
+  # informational only, see codecov.yml) this fails the build when any single
+  # source file drops below 80% line coverage. Runs once on ubuntu + Python
+  # 3.12; coverage is platform- and version-agnostic for this pure-Python
+  # library, so one cell is the authority.
+  coverage-gate:
+    name: Per-file coverage gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up uv and Python 3.12
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+          python-version: '3.12'
+
+      - name: Sync dev environment
+        run: uv sync --extra dev
+
+      - name: Run tests with coverage
+        env:
+          HYPOTHESIS_PROFILE: ci
+        run: uv run pytest tests/ --cov=src/tsbootstrap --cov-report=xml
+
+      - name: Generate coverage.json
+        run: uv run coverage json -o coverage.json
+
+      - name: Enforce per-file coverage threshold (>=80%)
+        # Excluded files are justified in the docstring table inside
+        # scripts/coverage_per_file.py. The only exclusion is the package
+        # __init__ re-export surface, which carries no logic.
+        run: |
+          test -s coverage.json || { echo 'coverage.json missing or empty: the coverage run did not produce data on this cell' >&2; exit 1; }
+          uv run python scripts/coverage_per_file.py coverage.json \
+            --exclude src/tsbootstrap/__init__.py
+
   # Execute the tutorial notebooks (issue #46: notebooks must run in CI).
   # This is the execution authority; the docs build only renders committed outputs.
   notebooks:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,12 @@ jobs:
     name: Upload wheels to PyPI
     runs-on: ubuntu-latest
     needs: [build_wheels,test_unix_wheels,test_windows_wheels]
+    # OIDC trusted publishing: the id-token permission lets PyPI verify this
+    # workflow's identity directly, so no long-lived API token (and no
+    # PYPI_TOKEN secret) is needed. attestations: true emits PEP 740
+    # provenance for the uploaded distributions.
+    permissions:
+      id-token: write
 
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -117,6 +123,6 @@ jobs:
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
-          password: ${{ secrets.PYPI_TOKEN }}
           packages-dir: wheelhouse/
           skip-existing: true
+          attestations: true

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+coverage.json
 *.cover
 *.py,cover
 .hypothesis/

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ authors:
   given-names: "Sankalp"
   orcid: "https://orcid.org/0000-0002-3645-4501"
 title: "tsbootstrap"
-version: 0.1.5
+version: 0.2.0
 doi: 10.5281/zenodo.8226495
 date-released: 2024/04/23
 url: "https://github.com/astrogilda/tsbootstrap"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,16 @@
+# Codecov is informational only. The blocking per-file coverage gate lives in
+# CI (scripts/coverage_per_file.py); codecov.io must never block a merge.
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+# No PR comment from codecov; the CI per-file gate is the authority.
+comment: false
+
+github_checks:
+  annotations: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -290,7 +290,19 @@ exclude = [".venv/*", "tests/*", "docs/*", "build/*", "dist/*", "src/tsbootstrap
 
 [tool.coverage.run]
 source = ['src/']
+branch = true
 omit = ['tests/*', '.venv/*']
+
+[tool.coverage.report]
+precision = 1
+show_missing = true
+skip_empty = true
+exclude_lines = [
+  "pragma: no cover",
+  "raise NotImplementedError",
+  "if TYPE_CHECKING:",
+  "if __name__ == \"__main__\":",
+]
 
 [tool.mypy]
 # Strict-minus typing gate for the tsbootstrap library (arch-style).

--- a/scripts/coverage_per_file.py
+++ b/scripts/coverage_per_file.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Per-file coverage threshold gate.
+
+Reads a ``coverage.json`` file produced by::
+
+    uv run pytest tests/ --cov=src/tsbootstrap --cov-report=xml
+    uv run coverage json -o coverage.json
+
+and fails (exit 1) if any non-excluded file's statement coverage is below the
+threshold. Unlike pytest-cov's ``--fail-under`` (which only checks the aggregate
+across the whole package), this script enforces the requirement independently
+for every source file, so a single well-covered module cannot mask an
+undertested one.
+
+Usage::
+
+    python scripts/coverage_per_file.py coverage.json
+    python scripts/coverage_per_file.py coverage.json --threshold 75
+    python scripts/coverage_per_file.py coverage.json --exclude src/tsbootstrap/api.py
+
+Exit codes:
+    0  All non-excluded files meet the threshold.
+    1  One or more files are below the threshold.
+    2  Input file missing or malformed.
+
+Justified exclusions
+--------------------
+Files passed to ``--exclude`` in CI must appear in the table below with a
+one-line rationale. Silent exclusions (not listed here) are not permitted:
+every excluded file must be documented here AND named in the CI step.
+
+First-principles policy: only genuinely-hard-to-unit-test files belong here
+(entry points, platform-specific branches). A file is never excluded merely to
+dodge writing tests; the default remedy for a low number is a test, not an
+exclusion entry.
+
+    src/tsbootstrap/__init__.py
+        Package entry point: re-export surface only (no logic). The module is
+        already omitted from the interrogate gate for the same reason. Its
+        statements are import-and-assign lines whose coverage tracks whatever
+        importer happens to run first; gating it adds noise, not signal.
+
+Add new entries in the format::
+
+    src/<path>: <one-line rationale>
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _load_coverage(path: Path) -> dict[str, Any]:
+    """Load and minimally validate coverage.json.
+
+    Parameters
+    ----------
+    path : Path
+        Path to the coverage JSON file.
+
+    Returns
+    -------
+    dict[str, Any]
+        Parsed JSON dictionary.
+
+    Raises
+    ------
+    SystemExit
+        On missing file or JSON parse error (exit code 2).
+    """
+    if not path.exists():
+        print(f"ERROR: coverage file not found: {path}", file=sys.stderr)
+        sys.exit(2)
+    try:
+        with path.open() as fh:
+            data: dict[str, Any] = json.load(fh)
+    except json.JSONDecodeError as exc:
+        print(f"ERROR: malformed JSON in {path}: {exc}", file=sys.stderr)
+        sys.exit(2)
+    if "files" not in data:
+        print(f"ERROR: 'files' key missing in {path}", file=sys.stderr)
+        sys.exit(2)
+    return data
+
+
+def _is_excluded(filepath: str, patterns: list[str]) -> bool:
+    """Return True if filepath matches any exclusion pattern.
+
+    Patterns are matched against the bare filepath as it appears in
+    coverage.json (typically a path relative to the project root). Both
+    fnmatch glob patterns and a plain suffix match are supported so an
+    exclusion entry can be written as either ``src/tsbootstrap/x.py`` or a
+    glob like ``src/tsbootstrap/**/x.py``.
+
+    Parameters
+    ----------
+    filepath : str
+        The file path string from coverage.json.
+    patterns : list[str]
+        List of exclusion patterns supplied via ``--exclude``.
+
+    Returns
+    -------
+    bool
+        True if any pattern matches.
+    """
+    return any(fnmatch.fnmatch(filepath, pat) or filepath.endswith(pat) for pat in patterns)
+
+
+def _run(
+    data: dict[str, Any],
+    threshold: float,
+    excludes: list[str],
+) -> int:
+    """Evaluate per-file coverage and print a results table.
+
+    Parameters
+    ----------
+    data : dict[str, Any]
+        Parsed coverage.json dictionary.
+    threshold : float
+        Minimum acceptable coverage percentage (0-100).
+    excludes : list[str]
+        File path patterns to skip.
+
+    Returns
+    -------
+    int
+        Exit code: 0 if all files pass, 1 if any fail.
+    """
+    files: dict[str, Any] = data["files"]
+
+    rows: list[tuple[str, float, int, bool, bool]] = []
+    # (filepath, pct, uncovered_count, excluded, passing)
+
+    for filepath, file_data in sorted(files.items()):
+        summary = file_data.get("summary", {})
+        pct: float = summary.get("percent_covered", 0.0)
+        missing: list[int] = file_data.get("missing_lines", [])
+        excluded = _is_excluded(filepath, excludes)
+        passing = excluded or pct >= threshold
+        rows.append((filepath, pct, len(missing), excluded, passing))
+
+    max_path = max((len(r[0]) for r in rows), default=4)
+    col_path = max(max_path, 4)
+
+    header = f"{'STATUS':<6}  {'COVERAGE':>8}  {'UNCOV':>5}  {'FILE':<{col_path}}"
+    separator = "-" * len(header)
+
+    print(f"\nPer-file coverage gate  (threshold: {threshold:.1f}%)\n")
+    print(header)
+    print(separator)
+
+    failing: list[str] = []
+    for filepath, pct, uncov, excluded, passing in rows:
+        if excluded:
+            status = "SKIP"
+        elif passing:
+            status = "PASS"
+        else:
+            status = "FAIL"
+            failing.append(filepath)
+        excl_tag = "  [excluded]" if excluded else ""
+        print(f"{status:<6}  {pct:>7.1f}%  {uncov:>5}  {filepath:<{col_path}}{excl_tag}")
+
+    print(separator)
+
+    total = len(rows)
+    skipped = sum(1 for _, _, _, exc, _ in rows if exc)
+    checked = total - skipped
+    passed = sum(1 for _, _, _, exc, ok in rows if not exc and ok)
+    n_failing = len(failing)
+
+    print(f"\n{checked} files checked ({skipped} skipped): {passed} PASS, {n_failing} FAIL\n")
+
+    if failing:
+        print(f"Files below {threshold:.1f}%:")
+        for fp in failing:
+            print(f"  {fp}")
+        print()
+        return 1
+
+    return 0
+
+
+def main() -> int:
+    """CLI entry point.
+
+    Returns
+    -------
+    int
+        Exit code (0 = all pass, 1 = failures, 2 = input error).
+    """
+    parser = argparse.ArgumentParser(
+        description="Per-file coverage threshold gate.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "coverage_json",
+        metavar="COVERAGE_JSON",
+        type=Path,
+        help="Path to coverage.json produced by `coverage json -o coverage.json`.",
+    )
+    parser.add_argument(
+        "--threshold",
+        metavar="N",
+        type=float,
+        default=80.0,
+        help="Minimum coverage percentage per file (default: 80).",
+    )
+    parser.add_argument(
+        "--exclude",
+        metavar="PATTERN",
+        action="append",
+        default=[],
+        dest="excludes",
+        help=(
+            "Exclude files matching PATTERN from the gate. Repeatable. Every "
+            "exclusion must be justified in the docstring table inside this script."
+        ),
+    )
+
+    args = parser.parse_args()
+
+    data = _load_coverage(args.coverage_json)
+    return _run(data, args.threshold, args.excludes)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/tsbootstrap/engines/var.py
+++ b/src/tsbootstrap/engines/var.py
@@ -28,7 +28,7 @@ try:  # optional [accel] extra: a compiled, replicate-parallel kernel for the ti
         innovations: NDArray[np.float64],
         p: int,
         m: int,
-    ) -> None:
+    ) -> None:  # pragma: no cover - numba njit-compiles this body to machine code, so coverage.py cannot trace the Python lines even when the kernel runs; correctness is pinned by test_var_numba_and_numpy_backends_agree
         # Fill path[:, p:] in place with X_t[i] = c[i] + e_t[i] + sum_j sum_k A_j[i,k] X_{t-1-j}[k].
         # The B replicates are independent and write disjoint path[b] slices, so prange over
         # b is data-race-free and deterministic; the time loop stays sequential per path.

--- a/tests/unit/test_batched_engine.py
+++ b/tests/unit/test_batched_engine.py
@@ -94,6 +94,53 @@ class TestVARBatchedEngine:
             )
             np.testing.assert_allclose(path_numpy, path_numba, rtol=1e-9, atol=1e-9)
 
+    def test_simulate_var_single_path(self):
+        # The single-path simulate_var must reproduce the VAR recursion
+        # X_t = c + sum_j A_j X_{t-j} + e_t exactly. Pin it against a hand-rolled
+        # reference loop so the public single-path entry point stays correct.
+        from tsbootstrap.engines.var import simulate_var
+
+        rng = np.random.default_rng(7)
+        p, d, m = 2, 3, 25
+        coefs = np.stack([0.2 / (j + 1) * np.eye(d) + 0.03 for j in range(p)])
+        intercept = rng.standard_normal(d) * 0.1
+        init = rng.standard_normal((p, d))
+        innovations = rng.standard_normal((m, d))
+
+        out = simulate_var(coefs, intercept, init, innovations)
+
+        assert out.shape == (p + m, d)
+        np.testing.assert_array_equal(out[:p], init)
+
+        expected = np.empty((p + m, d))
+        expected[:p] = init
+        for t in range(p, p + m):
+            acc = intercept.copy()
+            for j in range(p):
+                acc = acc + coefs[j] @ expected[t - 1 - j]
+            expected[t] = acc + innovations[t - p]
+        np.testing.assert_allclose(out, expected, rtol=1e-12, atol=1e-12)
+
+    def test_simulate_var_single_path_matches_batched(self):
+        # A single-path simulate_var with B=1 must agree with the numpy batched
+        # recursion to tight tolerance, tying the two public entry points together.
+        import tsbootstrap.engines.var as var_engine
+        from tsbootstrap.engines.var import simulate_var
+
+        rng = np.random.default_rng(11)
+        p, d, m = 1, 2, 40
+        coefs = np.stack([np.array([[0.5, 0.1], [0.2, 0.4]])])
+        intercept = rng.standard_normal(d) * 0.1
+        init = rng.standard_normal((p, d))
+        innovations = rng.standard_normal((m, d))
+
+        single = simulate_var(coefs, intercept, init, innovations)
+
+        path = np.empty((1, p + m, d))
+        path[:, :p] = init[None]
+        var_engine._var_recurrence_numpy(coefs, intercept, path, innovations[None], p, m)
+        np.testing.assert_allclose(single, path[0], rtol=1e-9, atol=1e-9)
+
     def test_var_numpy_fallback_through_dispatch(self, monkeypatch):
         # Force the pure-numpy VAR backend so the fallback stays exercised end-to-end even when
         # numba is installed (the dispatch would otherwise always pick the compiled kernel).


### PR DESCRIPTION
Modernizes the quality + release tooling (matches the waitbus reference).

- Add a blocking per-file 80% coverage gate (scripts/coverage_per_file.py + a CI job), replacing reliance on codecov.io's flaky default thresholds. codecov.io is made informational (codecov.yml). Coverage stays enforced, stricter (per-file, deterministic, in-CI).
- Cover engines/var.py to 100% (new simulate_var tests; numba kernel pragma'd) rather than excluding it.
- Migrate PyPI publishing to OIDC trusted publishing (drop the PYPI_TOKEN secret; permissions id-token: write + attestations).
- Fix the stale CITATION.cff (0.1.5 to 0.2.0).

Operator note: register the PyPI trusted publisher for tsbootstrap before the next tagged release, then the PYPI_TOKEN secret can be deleted.