### PR TITLE
docs: refresh tutorial notebooks for the 0.3.0 APIs

### DIFF
--- a/docs/source/tutorials/observation_resampling.ipynb
+++ b/docs/source/tutorials/observation_resampling.ipynb
@@ -18,10 +18,10 @@
    "id": "43f0b2c9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:15:07.508698Z",
-     "iopub.status.busy": "2026-06-22T16:15:07.508089Z",
-     "iopub.status.idle": "2026-06-22T16:15:08.320270Z",
-     "shell.execute_reply": "2026-06-22T16:15:08.318424Z"
+     "iopub.execute_input": "2026-06-24T01:07:34.027832Z",
+     "iopub.status.busy": "2026-06-24T01:07:34.027318Z",
+     "iopub.status.idle": "2026-06-24T01:07:35.285932Z",
+     "shell.execute_reply": "2026-06-24T01:07:35.284780Z"
     }
    },
    "outputs": [],
@@ -49,10 +49,10 @@
    "id": "4a5f3657",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:15:08.325219Z",
-     "iopub.status.busy": "2026-06-22T16:15:08.324855Z",
-     "iopub.status.idle": "2026-06-22T16:15:09.102499Z",
-     "shell.execute_reply": "2026-06-22T16:15:09.101563Z"
+     "iopub.execute_input": "2026-06-24T01:07:35.288629Z",
+     "iopub.status.busy": "2026-06-24T01:07:35.288346Z",
+     "iopub.status.idle": "2026-06-24T01:07:36.110892Z",
+     "shell.execute_reply": "2026-06-24T01:07:36.110165Z"
     }
    },
    "outputs": [
@@ -107,10 +107,10 @@
    "id": "60079112",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:15:09.105810Z",
-     "iopub.status.busy": "2026-06-22T16:15:09.105558Z",
-     "iopub.status.idle": "2026-06-22T16:15:09.347441Z",
-     "shell.execute_reply": "2026-06-22T16:15:09.346221Z"
+     "iopub.execute_input": "2026-06-24T01:07:36.112918Z",
+     "iopub.status.busy": "2026-06-24T01:07:36.112756Z",
+     "iopub.status.idle": "2026-06-24T01:07:36.365272Z",
+     "shell.execute_reply": "2026-06-24T01:07:36.364176Z"
     }
    },
    "outputs": [
@@ -155,10 +155,10 @@
    "id": "dfc22aee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:15:09.350335Z",
-     "iopub.status.busy": "2026-06-22T16:15:09.350146Z",
-     "iopub.status.idle": "2026-06-22T16:15:09.355898Z",
-     "shell.execute_reply": "2026-06-22T16:15:09.354893Z"
+     "iopub.execute_input": "2026-06-24T01:07:36.370015Z",
+     "iopub.status.busy": "2026-06-24T01:07:36.369702Z",
+     "iopub.status.idle": "2026-06-24T01:07:36.380898Z",
+     "shell.execute_reply": "2026-06-24T01:07:36.378840Z"
     }
    },
    "outputs": [],
@@ -205,10 +205,10 @@
    "id": "78e9b95c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:15:09.358212Z",
-     "iopub.status.busy": "2026-06-22T16:15:09.358027Z",
-     "iopub.status.idle": "2026-06-22T16:15:09.830534Z",
-     "shell.execute_reply": "2026-06-22T16:15:09.829146Z"
+     "iopub.execute_input": "2026-06-24T01:07:36.384631Z",
+     "iopub.status.busy": "2026-06-24T01:07:36.384028Z",
+     "iopub.status.idle": "2026-06-24T01:07:36.775376Z",
+     "shell.execute_reply": "2026-06-24T01:07:36.773888Z"
     }
    },
    "outputs": [
@@ -258,10 +258,10 @@
    "id": "ce383acf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:15:09.833123Z",
-     "iopub.status.busy": "2026-06-22T16:15:09.832958Z",
-     "iopub.status.idle": "2026-06-22T16:15:09.974519Z",
-     "shell.execute_reply": "2026-06-22T16:15:09.973078Z"
+     "iopub.execute_input": "2026-06-24T01:07:36.777960Z",
+     "iopub.status.busy": "2026-06-24T01:07:36.777775Z",
+     "iopub.status.idle": "2026-06-24T01:07:36.920803Z",
+     "shell.execute_reply": "2026-06-24T01:07:36.919513Z"
     }
    },
    "outputs": [
@@ -302,10 +302,10 @@
    "id": "c39896cc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:15:09.977435Z",
-     "iopub.status.busy": "2026-06-22T16:15:09.977248Z",
-     "iopub.status.idle": "2026-06-22T16:15:10.146192Z",
-     "shell.execute_reply": "2026-06-22T16:15:10.144613Z"
+     "iopub.execute_input": "2026-06-24T01:07:36.925469Z",
+     "iopub.status.busy": "2026-06-24T01:07:36.925271Z",
+     "iopub.status.idle": "2026-06-24T01:07:37.097601Z",
+     "shell.execute_reply": "2026-06-24T01:07:37.096861Z"
     }
    },
    "outputs": [
@@ -347,10 +347,10 @@
    "id": "e9db98a5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:15:10.149241Z",
-     "iopub.status.busy": "2026-06-22T16:15:10.149097Z",
-     "iopub.status.idle": "2026-06-22T16:15:10.297477Z",
-     "shell.execute_reply": "2026-06-22T16:15:10.296335Z"
+     "iopub.execute_input": "2026-06-24T01:07:37.102481Z",
+     "iopub.status.busy": "2026-06-24T01:07:37.102303Z",
+     "iopub.status.idle": "2026-06-24T01:07:37.251783Z",
+     "shell.execute_reply": "2026-06-24T01:07:37.251113Z"
     }
    },
    "outputs": [
@@ -392,10 +392,10 @@
    "id": "cae797f8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:15:10.302681Z",
-     "iopub.status.busy": "2026-06-22T16:15:10.302527Z",
-     "iopub.status.idle": "2026-06-22T16:15:10.446419Z",
-     "shell.execute_reply": "2026-06-22T16:15:10.444966Z"
+     "iopub.execute_input": "2026-06-24T01:07:37.258160Z",
+     "iopub.status.busy": "2026-06-24T01:07:37.257951Z",
+     "iopub.status.idle": "2026-06-24T01:07:37.500000Z",
+     "shell.execute_reply": "2026-06-24T01:07:37.498504Z"
     }
    },
    "outputs": [
@@ -437,10 +437,10 @@
    "id": "ca5bc411",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:15:10.449018Z",
-     "iopub.status.busy": "2026-06-22T16:15:10.448807Z",
-     "iopub.status.idle": "2026-06-22T16:15:10.676400Z",
-     "shell.execute_reply": "2026-06-22T16:15:10.675168Z"
+     "iopub.execute_input": "2026-06-24T01:07:37.503051Z",
+     "iopub.status.busy": "2026-06-24T01:07:37.502833Z",
+     "iopub.status.idle": "2026-06-24T01:07:37.735162Z",
+     "shell.execute_reply": "2026-06-24T01:07:37.733274Z"
     }
    },
    "outputs": [
@@ -498,10 +498,10 @@
    "id": "024f3d08",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:15:10.680827Z",
-     "iopub.status.busy": "2026-06-22T16:15:10.680615Z",
-     "iopub.status.idle": "2026-06-22T16:15:10.711109Z",
-     "shell.execute_reply": "2026-06-22T16:15:10.710192Z"
+     "iopub.execute_input": "2026-06-24T01:07:37.739513Z",
+     "iopub.status.busy": "2026-06-24T01:07:37.739232Z",
+     "iopub.status.idle": "2026-06-24T01:07:37.772468Z",
+     "shell.execute_reply": "2026-06-24T01:07:37.770676Z"
     }
    },
    "outputs": [
@@ -585,10 +585,10 @@
    "id": "d09c28ed",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:15:10.715140Z",
-     "iopub.status.busy": "2026-06-22T16:15:10.714905Z",
-     "iopub.status.idle": "2026-06-22T16:15:11.005186Z",
-     "shell.execute_reply": "2026-06-22T16:15:11.004127Z"
+     "iopub.execute_input": "2026-06-24T01:07:37.777232Z",
+     "iopub.status.busy": "2026-06-24T01:07:37.776739Z",
+     "iopub.status.idle": "2026-06-24T01:07:38.038619Z",
+     "shell.execute_reply": "2026-06-24T01:07:38.036733Z"
     },
     "nbsphinx-thumbnail": {
      "output-index": 0
@@ -672,10 +672,10 @@
    "id": "a05b6682",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:15:11.007944Z",
-     "iopub.status.busy": "2026-06-22T16:15:11.007713Z",
-     "iopub.status.idle": "2026-06-22T16:15:11.018740Z",
-     "shell.execute_reply": "2026-06-22T16:15:11.017812Z"
+     "iopub.execute_input": "2026-06-24T01:07:38.043436Z",
+     "iopub.status.busy": "2026-06-24T01:07:38.042871Z",
+     "iopub.status.idle": "2026-06-24T01:07:38.060154Z",
+     "shell.execute_reply": "2026-06-24T01:07:38.058210Z"
     }
    },
    "outputs": [
@@ -764,6 +764,24 @@
     "### Picking among the six\n",
     "\n",
     "All six methods here resample the rows you observed, so they keep the empirical marginal and expose out-of-bag structure. They differ in how they stitch blocks together: IID not at all, the moving and non-overlapping blocks with hard seams, the circular block with wrap-around, the stationary block with random lengths, and the tapered block with down-weighted edges. Pick by what your series and estimator can tolerate, and let `\"auto\"` set the length unless you have a reason to override it."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "08757247",
+   "metadata": {},
+   "source": [
+    "### An opt-in compiled backend\n",
+    "\n",
+    "Five of these methods, IID, MovingBlock, CircularBlock, StationaryBlock, and NonOverlappingBlock, can run on a numba kernel by passing `backend=\"compiled\"` to the same `bootstrap(...)` call:\n",
+    "\n",
+    "```python\n",
+    "bootstrap(x, method=MovingBlock(block_length=\"auto\"), n_bootstraps=B, random_state=0, backend=\"compiled\")\n",
+    "```\n",
+    "\n",
+    "This path needs the `[accel]` extra installed. It is equal in distribution to the default numpy path but draws from a distinct Philox stream, so the replicates are not bit-identical to the default backend even with the same `random_state`.\n",
+    "\n",
+    "TaperedBlock is the one method in this tour outside the compiled-supported set, so pairing it with `backend=\"compiled\"` raises `MethodConfigError` before any fit runs."
    ]
   }
  ],

--- a/docs/source/tutorials/provenance_and_scaling.ipynb
+++ b/docs/source/tutorials/provenance_and_scaling.ipynb
@@ -18,10 +18,10 @@
    "id": "29540429",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:15:15.737261Z",
-     "iopub.status.busy": "2026-06-22T16:15:15.736984Z",
-     "iopub.status.idle": "2026-06-22T16:15:16.568891Z",
-     "shell.execute_reply": "2026-06-22T16:15:16.567835Z"
+     "iopub.execute_input": "2026-06-24T01:07:42.760179Z",
+     "iopub.status.busy": "2026-06-24T01:07:42.759929Z",
+     "iopub.status.idle": "2026-06-24T01:07:43.622034Z",
+     "shell.execute_reply": "2026-06-24T01:07:43.620571Z"
     }
    },
    "outputs": [],
@@ -49,10 +49,10 @@
    "id": "05ce846f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:15:16.573278Z",
-     "iopub.status.busy": "2026-06-22T16:15:16.572817Z",
-     "iopub.status.idle": "2026-06-22T16:15:16.898247Z",
-     "shell.execute_reply": "2026-06-22T16:15:16.897307Z"
+     "iopub.execute_input": "2026-06-24T01:07:43.626439Z",
+     "iopub.status.busy": "2026-06-24T01:07:43.626000Z",
+     "iopub.status.idle": "2026-06-24T01:07:43.960472Z",
+     "shell.execute_reply": "2026-06-24T01:07:43.959429Z"
     }
    },
    "outputs": [
@@ -105,10 +105,10 @@
    "id": "7c0e25c7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:15:16.901405Z",
-     "iopub.status.busy": "2026-06-22T16:15:16.901089Z",
-     "iopub.status.idle": "2026-06-22T16:15:17.178100Z",
-     "shell.execute_reply": "2026-06-22T16:15:17.176331Z"
+     "iopub.execute_input": "2026-06-24T01:07:43.964100Z",
+     "iopub.status.busy": "2026-06-24T01:07:43.963853Z",
+     "iopub.status.idle": "2026-06-24T01:07:44.188207Z",
+     "shell.execute_reply": "2026-06-24T01:07:44.187174Z"
     }
    },
    "outputs": [
@@ -166,10 +166,10 @@
    "id": "b75e5ccd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:15:17.182018Z",
-     "iopub.status.busy": "2026-06-22T16:15:17.181798Z",
-     "iopub.status.idle": "2026-06-22T16:15:17.522048Z",
-     "shell.execute_reply": "2026-06-22T16:15:17.520070Z"
+     "iopub.execute_input": "2026-06-24T01:07:44.191964Z",
+     "iopub.status.busy": "2026-06-24T01:07:44.191813Z",
+     "iopub.status.idle": "2026-06-24T01:07:44.456705Z",
+     "shell.execute_reply": "2026-06-24T01:07:44.454790Z"
     }
    },
    "outputs": [
@@ -320,10 +320,10 @@
    "id": "b32d996f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:15:17.526426Z",
-     "iopub.status.busy": "2026-06-22T16:15:17.525937Z",
-     "iopub.status.idle": "2026-06-22T16:15:17.541591Z",
-     "shell.execute_reply": "2026-06-22T16:15:17.540178Z"
+     "iopub.execute_input": "2026-06-24T01:07:44.460681Z",
+     "iopub.status.busy": "2026-06-24T01:07:44.460219Z",
+     "iopub.status.idle": "2026-06-24T01:07:44.470815Z",
+     "shell.execute_reply": "2026-06-24T01:07:44.469865Z"
     }
    },
    "outputs": [
@@ -332,7 +332,7 @@
      "output_type": "stream",
      "text": [
       "random_state_kind: 'none'\n",
-      "recorded seed_entropy: 278104144765395418338305278694271410265\n",
+      "recorded seed_entropy: 241030189321615554197432467218918731436\n",
       "replay from recorded entropy reproduces the run: True\n"
      ]
     }
@@ -373,10 +373,10 @@
    "id": "60aa980c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:15:17.544651Z",
-     "iopub.status.busy": "2026-06-22T16:15:17.544443Z",
-     "iopub.status.idle": "2026-06-22T16:15:17.677978Z",
-     "shell.execute_reply": "2026-06-22T16:15:17.676691Z"
+     "iopub.execute_input": "2026-06-24T01:07:44.473835Z",
+     "iopub.status.busy": "2026-06-24T01:07:44.473612Z",
+     "iopub.status.idle": "2026-06-24T01:07:44.589156Z",
+     "shell.execute_reply": "2026-06-24T01:07:44.587801Z"
     }
    },
    "outputs": [
@@ -415,6 +415,73 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f618efce",
+   "metadata": {},
+   "source": [
+    "### Named reducers for the common statistics\n",
+    "\n",
+    "Writing the callable above is worth doing once, because it teaches the contract. For the everyday statistics you do not have to. Pass a string and `bootstrap_reduce` uses a built-in reducer: `\"mean\"`, `\"var\"` (population variance, `ddof=0`), and `\"std\"` (population standard deviation, `ddof=0`). A quantile reducer is the tuple form `(\"quantile\", q)` with `q` in `[0, 1]`. The named path produces the same `.statistics` the hand-written callable does, so the two are interchangeable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "a2ad0b8c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-24T01:07:44.594403Z",
+     "iopub.status.busy": "2026-06-24T01:07:44.594246Z",
+     "iopub.status.idle": "2026-06-24T01:07:44.691921Z",
+     "shell.execute_reply": "2026-06-24T01:07:44.690528Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "named.statistics shape: (5000,)\n",
+      "named 'mean' matches the callable: True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# statistic=\"mean\" gives the same result as the hand-written replicate_mean callable.\n",
+    "named = bootstrap_reduce(\n",
+    "    x,\n",
+    "    method=MovingBlock(block_length=10),\n",
+    "    statistic=\"mean\",\n",
+    "    n_bootstraps=B_large,\n",
+    "    random_state=0,\n",
+    ")\n",
+    "\n",
+    "print(f\"named.statistics shape: {named.statistics.shape}\")\n",
+    "print(f\"named 'mean' matches the callable: {np.array_equal(named.statistics, reduced.statistics)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "98b594dc",
+   "metadata": {},
+   "source": [
+    "### A compiled backend for the reduce path\n",
+    "\n",
+    "A named reducer also unlocks a faster execution path. With the `[accel]` extra installed, `backend=\"compiled\"` fuses build, gather, and reduce into one replicate-parallel pass for `bootstrap_reduce`, which cuts the per-replicate overhead at large `B`. It requires a named or tuple reducer; a Python callable raises `MethodConfigError` on the compiled path, because the fused kernel cannot call back into arbitrary Python per replicate. The compiled path is equal in distribution to the numpy path but not bitwise-identical, so the default `backend=\"numpy\"` stays the reproducible path used everywhere else in this notebook. A compiled run looks like this:\n",
+    "\n",
+    "```python\n",
+    "fast = bootstrap_reduce(\n",
+    "    x,\n",
+    "    method=MovingBlock(block_length=10),\n",
+    "    statistic=\"mean\",\n",
+    "    n_bootstraps=B_large,\n",
+    "    random_state=0,\n",
+    "    backend=\"compiled\",\n",
+    ")\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "524e3fea",
    "metadata": {},
    "source": [
@@ -425,14 +492,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "c40eddc5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:15:17.681523Z",
-     "iopub.status.busy": "2026-06-22T16:15:17.681387Z",
-     "iopub.status.idle": "2026-06-22T16:15:17.686347Z",
-     "shell.execute_reply": "2026-06-22T16:15:17.685417Z"
+     "iopub.execute_input": "2026-06-24T01:07:44.696759Z",
+     "iopub.status.busy": "2026-06-24T01:07:44.696603Z",
+     "iopub.status.idle": "2026-06-24T01:07:44.701861Z",
+     "shell.execute_reply": "2026-06-24T01:07:44.700796Z"
     }
    },
    "outputs": [
@@ -466,14 +533,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "f5a3f422",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:15:17.688588Z",
-     "iopub.status.busy": "2026-06-22T16:15:17.688464Z",
-     "iopub.status.idle": "2026-06-22T16:15:17.698222Z",
-     "shell.execute_reply": "2026-06-22T16:15:17.697184Z"
+     "iopub.execute_input": "2026-06-24T01:07:44.707168Z",
+     "iopub.status.busy": "2026-06-24T01:07:44.706926Z",
+     "iopub.status.idle": "2026-06-24T01:07:44.720183Z",
+     "shell.execute_reply": "2026-06-24T01:07:44.718400Z"
     }
    },
    "outputs": [
@@ -533,7 +600,7 @@
        "reduced path    (B, 1) = (5000, 1)         5000       0.04"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -557,6 +624,61 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d62ce88b",
+   "metadata": {},
+   "source": [
+    "### Halving the path tensor with float32\n",
+    "\n",
+    "The reduced path shrinks what you keep. When you do hold the full path tensor, `dtype=\"float32\"` halves its footprint. It works on both `bootstrap` and `bootstrap_reduce`: the returned path tensor is cast to 32-bit, so at large `B` it occupies half the memory of the default 64-bit tensor. The cast is faithful, not a different numerical path. Model fits, the autocovariance, and the reduction buffer all stay float64; only the returned path is down-cast at the end. Any string other than `\"float32\"` or `\"float64\"` raises `MethodConfigError`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "a3f9449e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-24T01:07:44.727091Z",
+     "iopub.status.busy": "2026-06-24T01:07:44.726617Z",
+     "iopub.status.idle": "2026-06-24T01:07:44.955724Z",
+     "shell.execute_reply": "2026-06-24T01:07:44.954290Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "default dtype: float64   bytes: 4800000\n",
+      "float32 dtype: float32   bytes: 2400000\n",
+      "footprint ratio (float32 / float64): 0.50\n",
+      "float32 path matches float64 path: True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# float32 halves the path-tensor footprint. Compare the dtype of the returned values.\n",
+    "paths64 = bootstrap(x, method=MovingBlock(block_length=10), n_bootstraps=B_large, random_state=0)\n",
+    "paths32 = bootstrap(\n",
+    "    x,\n",
+    "    method=MovingBlock(block_length=10),\n",
+    "    n_bootstraps=B_large,\n",
+    "    random_state=0,\n",
+    "    dtype=\"float32\",\n",
+    ")\n",
+    "\n",
+    "v64 = paths64.values()\n",
+    "v32 = paths32.values()\n",
+    "print(f\"default dtype: {v64.dtype}   bytes: {v64.nbytes}\")\n",
+    "print(f\"float32 dtype: {v32.dtype}   bytes: {v32.nbytes}\")\n",
+    "print(f\"footprint ratio (float32 / float64): {v32.nbytes / v64.nbytes:.2f}\")\n",
+    "\n",
+    "# The down-cast is faithful: float32 values match float64 to single-precision tolerance.\n",
+    "print(f\"float32 path matches float64 path: {np.allclose(v32, v64, atol=1e-6)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "f5d2af55",
    "metadata": {},
    "source": [
@@ -567,14 +689,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "id": "db1f448e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:15:17.700025Z",
-     "iopub.status.busy": "2026-06-22T16:15:17.699882Z",
-     "iopub.status.idle": "2026-06-22T16:15:17.747519Z",
-     "shell.execute_reply": "2026-06-22T16:15:17.746813Z"
+     "iopub.execute_input": "2026-06-24T01:07:44.960493Z",
+     "iopub.status.busy": "2026-06-24T01:07:44.960257Z",
+     "iopub.status.idle": "2026-06-24T01:07:45.021006Z",
+     "shell.execute_reply": "2026-06-24T01:07:45.018866Z"
     }
    },
    "outputs": [
@@ -638,7 +760,7 @@
        "abs. difference    0.000000     0.000000"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -670,14 +792,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "id": "ci-agreement",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:15:17.752143Z",
-     "iopub.status.busy": "2026-06-22T16:15:17.751990Z",
-     "iopub.status.idle": "2026-06-22T16:15:17.891927Z",
-     "shell.execute_reply": "2026-06-22T16:15:17.889851Z"
+     "iopub.execute_input": "2026-06-24T01:07:45.026506Z",
+     "iopub.status.busy": "2026-06-24T01:07:45.026214Z",
+     "iopub.status.idle": "2026-06-24T01:07:45.173245Z",
+     "shell.execute_reply": "2026-06-24T01:07:45.171959Z"
     }
    },
    "outputs": [
@@ -755,14 +877,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "id": "a06718ef",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:15:17.897408Z",
-     "iopub.status.busy": "2026-06-22T16:15:17.896756Z",
-     "iopub.status.idle": "2026-06-22T16:15:18.373064Z",
-     "shell.execute_reply": "2026-06-22T16:15:18.371825Z"
+     "iopub.execute_input": "2026-06-24T01:07:45.177767Z",
+     "iopub.status.busy": "2026-06-24T01:07:45.177576Z",
+     "iopub.status.idle": "2026-06-24T01:07:45.632288Z",
+     "shell.execute_reply": "2026-06-24T01:07:45.630781Z"
     },
     "nbsphinx-thumbnail": {
      "output-index": 0
@@ -851,6 +973,60 @@
     "## Closing the loop on reproducibility\n",
     "\n",
     "A fixed integer seed gives bitwise-identical results no matter how the work is parallelised. Every run records the entropy and the library versions needed to replay or cite it. And `bootstrap_reduce` scales the replicate count to whatever your calibration needs without holding the full `(B, n)` array in memory, while returning the same quantiles the full array would."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1966113c",
+   "metadata": {},
+   "source": [
+    "## Scaling across many series at once\n",
+    "\n",
+    "The same memory-bounded reduce extends to a panel of series. `bootstrap_reduce_panel` bootstraps each series and reduces it in the same pass, returning one statistic array for the whole panel instead of looping in Python. Pass the panel as a list of per-series arrays (ragged lengths are fine) with `indptr=None`, or as a single flat array plus a CSR `indptr` of shape `(num_series + 1,)` that marks where each series begins and ends. The `.statistics` shape is `(n_bootstraps, num_series, |theta|)`, collapsing to `(n_bootstraps, num_series)` for a univariate panel with a scalar statistic. Only the observation methods are supported here (`IID`, `MovingBlock`, `CircularBlock`, `StationaryBlock`, `NonOverlappingBlock`); a recursive or model-based method raises `MethodConfigError`, because the panel path resamples observations rather than fitting a model per series."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "bcd80eb5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-24T01:07:45.637629Z",
+     "iopub.status.busy": "2026-06-24T01:07:45.637379Z",
+     "iopub.status.idle": "2026-06-24T01:07:45.915459Z",
+     "shell.execute_reply": "2026-06-24T01:07:45.913907Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "panel.statistics shape: (999, 3)   # (n_bootstraps, num_series)\n",
+      "per-series mean of the bootstrap means: [ 0.12489043 -0.22022554 -0.20741821]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from tsbootstrap import bootstrap_reduce_panel\n",
+    "\n",
+    "# Three AR(1) series of equal length, built with a local generator so this cell\n",
+    "# is self-contained (no bundled datasets needed).\n",
+    "panel_rng = np.random.default_rng(0)\n",
+    "series_a = ar1(120, PHI, panel_rng)\n",
+    "series_b = ar1(120, PHI, panel_rng)\n",
+    "series_c = ar1(120, PHI, panel_rng)\n",
+    "\n",
+    "panel = bootstrap_reduce_panel(\n",
+    "    [series_a, series_b, series_c],\n",
+    "    method=MovingBlock(block_length=\"auto\"),\n",
+    "    statistic=\"mean\",\n",
+    "    n_bootstraps=999,\n",
+    "    random_state=0,\n",
+    ")\n",
+    "\n",
+    "print(f\"panel.statistics shape: {panel.statistics.shape}   # (n_bootstraps, num_series)\")\n",
+    "print(f\"per-series mean of the bootstrap means: {panel.statistics.mean(axis=0)}\")"
    ]
   }
  ],

--- a/docs/source/tutorials/quickstart.ipynb
+++ b/docs/source/tutorials/quickstart.ipynb
@@ -18,10 +18,10 @@
    "id": "e17845da",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:15:22.542896Z",
-     "iopub.status.busy": "2026-06-22T16:15:22.542695Z",
-     "iopub.status.idle": "2026-06-22T16:15:23.472975Z",
-     "shell.execute_reply": "2026-06-22T16:15:23.471252Z"
+     "iopub.execute_input": "2026-06-24T01:07:50.695085Z",
+     "iopub.status.busy": "2026-06-24T01:07:50.694853Z",
+     "iopub.status.idle": "2026-06-24T01:07:51.552976Z",
+     "shell.execute_reply": "2026-06-24T01:07:51.552272Z"
     }
    },
    "outputs": [],
@@ -49,10 +49,10 @@
    "id": "ac59fb3a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:15:23.476695Z",
-     "iopub.status.busy": "2026-06-22T16:15:23.476274Z",
-     "iopub.status.idle": "2026-06-22T16:15:23.487664Z",
-     "shell.execute_reply": "2026-06-22T16:15:23.486182Z"
+     "iopub.execute_input": "2026-06-24T01:07:51.555674Z",
+     "iopub.status.busy": "2026-06-24T01:07:51.555449Z",
+     "iopub.status.idle": "2026-06-24T01:07:51.561832Z",
+     "shell.execute_reply": "2026-06-24T01:07:51.560787Z"
     }
    },
    "outputs": [
@@ -95,10 +95,10 @@
    "id": "42dcf52d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:15:23.490925Z",
-     "iopub.status.busy": "2026-06-22T16:15:23.490619Z",
-     "iopub.status.idle": "2026-06-22T16:15:23.705580Z",
-     "shell.execute_reply": "2026-06-22T16:15:23.704766Z"
+     "iopub.execute_input": "2026-06-24T01:07:51.563952Z",
+     "iopub.status.busy": "2026-06-24T01:07:51.563820Z",
+     "iopub.status.idle": "2026-06-24T01:07:51.716177Z",
+     "shell.execute_reply": "2026-06-24T01:07:51.715265Z"
     }
    },
    "outputs": [
@@ -123,6 +123,23 @@
   },
   {
    "cell_type": "markdown",
+   "id": "de53b8b1",
+   "metadata": {},
+   "source": [
+    "## Going faster (optional)\n",
+    "\n",
+    "For larger runs, `bootstrap` accepts `backend=\"compiled\"`, an opt-in numba-accelerated\n",
+    "fast path. It is equal in distribution to the default numpy path but not bit-identical,\n",
+    "so individual replicates differ even with the same `random_state`. It needs the extra\n",
+    "dependency, installed with `pip install \"tsbootstrap[accel]\"`.\n",
+    "\n",
+    "```python\n",
+    "result_fast = bootstrap(x, method=MovingBlock(block_length=\"auto\"), n_bootstraps=200, random_state=0, backend=\"compiled\")\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "0d047122",
    "metadata": {},
    "source": [
@@ -138,10 +155,10 @@
    "id": "87f7bca6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:15:23.708403Z",
-     "iopub.status.busy": "2026-06-22T16:15:23.708239Z",
-     "iopub.status.idle": "2026-06-22T16:15:23.713181Z",
-     "shell.execute_reply": "2026-06-22T16:15:23.712444Z"
+     "iopub.execute_input": "2026-06-24T01:07:51.719699Z",
+     "iopub.status.busy": "2026-06-24T01:07:51.719417Z",
+     "iopub.status.idle": "2026-06-24T01:07:51.725549Z",
+     "shell.execute_reply": "2026-06-24T01:07:51.724632Z"
     }
    },
    "outputs": [
@@ -179,10 +196,10 @@
    "id": "5afec912",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:15:23.715008Z",
-     "iopub.status.busy": "2026-06-22T16:15:23.714882Z",
-     "iopub.status.idle": "2026-06-22T16:15:24.055904Z",
-     "shell.execute_reply": "2026-06-22T16:15:24.054825Z"
+     "iopub.execute_input": "2026-06-24T01:07:51.730026Z",
+     "iopub.status.busy": "2026-06-24T01:07:51.729793Z",
+     "iopub.status.idle": "2026-06-24T01:07:51.997823Z",
+     "shell.execute_reply": "2026-06-24T01:07:51.996935Z"
     }
    },
    "outputs": [
@@ -219,10 +236,10 @@
    "id": "22b954f1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:15:24.059318Z",
-     "iopub.status.busy": "2026-06-22T16:15:24.058928Z",
-     "iopub.status.idle": "2026-06-22T16:15:24.573551Z",
-     "shell.execute_reply": "2026-06-22T16:15:24.572319Z"
+     "iopub.execute_input": "2026-06-24T01:07:52.002601Z",
+     "iopub.status.busy": "2026-06-24T01:07:52.002240Z",
+     "iopub.status.idle": "2026-06-24T01:07:52.523298Z",
+     "shell.execute_reply": "2026-06-24T01:07:52.522392Z"
     },
     "nbsphinx-thumbnail": {
      "output-index": 0


### PR DESCRIPTION
Adds compiled-backend, named-reducer, float32-dtype, and panel-reduce examples to the quickstart, observation-resampling, and provenance/scaling tutorials. Runnable cells use the default numpy backend; compiled-backend usage is shown as code snippets so the notebook CI runs without the accel extra. Outputs regenerated and verified.