### PR TITLE
Make the pre-push gate version-controlled and CI-accurate

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Version-controlled pre-push gate. It mirrors the CI quality checks that need no
+# network, so a lint or type failure is caught here instead of after the push.
+#
+# Parity with CI is the whole point: the Types job in CI.yml runs mypy and pyright
+# AFTER `uv sync --extra dev --extra mcp`, so the type annotations that reference the
+# optional `mcp` package resolve. This hook therefore runs the type checks through
+# `uv run --extra dev --extra mcp`; without those extras pyright reports the MCP
+# server's return type as unknown and the hook fails where CI would pass.
+#
+# Enable this hook once per clone with:
+#   git config core.hooksPath .githooks
+# (or run scripts/install-hooks.sh). Skip in an emergency with:
+#   PRE_PUSH_SKIP=1 git push
+#
+# The full docs -W build and SonarCloud run only in CI; run them manually before a
+# release push with `uv run make -C docs html SPHINXOPTS="-W"` and scripts/sonar-local.sh.
+set -uo pipefail
+
+if [ "${PRE_PUSH_SKIP:-0}" = "1" ]; then
+  echo "[pre-push] skipped via PRE_PUSH_SKIP=1"
+  exit 0
+fi
+
+# Skip the code gate for pure branch deletions (no commits are pushed).
+_zero="0000000000000000000000000000000000000000"
+_saw=0; _nondel=0
+while read -r _lref _lsha _rref _rsha; do
+  [ -z "${_lref:-}" ] && continue
+  _saw=1
+  [ "$_lsha" != "$_zero" ] && _nondel=1
+done
+if [ "$_saw" = "1" ] && [ "$_nondel" = "0" ]; then
+  echo "[pre-push] deletion-only push; skipping code gate"
+  exit 0
+fi
+
+cd "$(git rev-parse --show-toplevel)" || exit 1
+
+# Extras the CI Types job installs before running mypy and pyright. Keeping this in
+# one place makes the parity explicit and easy to update alongside CI.yml.
+CI_TYPE_EXTRAS=(--extra dev --extra mcp)
+
+fail=0
+run() {
+  echo "[pre-push] $1"
+  shift
+  if ! "$@"; then
+    echo "[pre-push] FAILED: $*"
+    fail=1
+  fi
+}
+
+run "ruff check"          uv run ruff check .
+run "ruff format --check" uv run ruff format --check .
+run "mypy"                uv run "${CI_TYPE_EXTRAS[@]}" mypy src/tsbootstrap
+run "pyright"             uv run "${CI_TYPE_EXTRAS[@]}" pyright src/tsbootstrap
+
+if [ "$fail" -ne 0 ]; then
+  echo "[pre-push] blocked: fix the above before pushing (or PRE_PUSH_SKIP=1 to override)."
+  exit 1
+fi
+echo "[pre-push] local gates passed"
+exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,11 +41,19 @@ uv sync --extra dev
 ```
 uv sync builds the locked virtual environment with an editable install, so your edits take effect immediately. Invoke tools with `uv run`, e.g. `uv run pytest`.
 
-3. Install the pre-commit hooks:
+3. Install the hooks:
 ```sh
 uv run pre-commit install
+scripts/install-hooks.sh
 ```
-The hooks run Ruff (lint and format) and the other code-quality checks on each commit.
+`pre-commit install` runs Ruff (lint and format) on each commit. `scripts/install-hooks.sh`
+points the clone at `.githooks/`, enabling the version-controlled pre-push gate that runs
+Ruff, mypy, and pyright with the same `--extra dev --extra mcp` extras CI uses, so a type
+error involving an optional dependency is caught locally instead of on the pull request.
+Skip the pre-push gate in an emergency with `PRE_PUSH_SKIP=1 git push`.
+
+To reproduce the SonarCloud scan locally before pushing, set `SONAR_TOKEN` and run
+`scripts/sonar-local.sh` (optionally passing a coverage XML path).
 
 4. Verify the installation:
 ```sh

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Point this clone at the version-controlled hooks in .githooks/ so every
+# contributor runs the same pre-push gate. Idempotent: safe to run repeatedly.
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+git config core.hooksPath .githooks
+echo "core.hooksPath set to .githooks; pre-push gate is active for this clone."

--- a/scripts/sonar-local.sh
+++ b/scripts/sonar-local.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Run a SonarCloud analysis from a developer machine, using the same project key,
+# organization, and exclusions that CI uses (read from sonar-project.properties).
+#
+# CI uses SonarCloud automatic analysis, which has no merge-gating power here; this
+# script lets you reproduce the same scan locally before pushing so a new bug or
+# security finding does not surprise you on the PR.
+#
+# Requirements:
+#   - SONAR_TOKEN in the environment (a SonarCloud user token with analysis rights).
+#     Generate one at https://sonarcloud.io/account/security and export it, or store
+#     it in the keyring and load it, for example:
+#       export SONAR_TOKEN="$(secret-tool lookup service sonarcloud account token)"
+#   - Either the sonar-scanner CLI on PATH, or Docker (the script falls back to the
+#     official sonarsource/sonar-scanner-cli image).
+#
+# Coverage: pass a coverage XML path as the first argument to include coverage in
+# the scan, for example:
+#   uv run python -m pytest tests/ --cov=src/tsbootstrap --cov-report=xml
+#   scripts/sonar-local.sh coverage.xml
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+if [ -z "${SONAR_TOKEN:-}" ]; then
+  echo "error: SONAR_TOKEN is not set. See the header of this script for how to provide it." >&2
+  exit 1
+fi
+
+COVERAGE_ARG=()
+if [ -n "${1:-}" ]; then
+  if [ ! -f "$1" ]; then
+    echo "error: coverage file '$1' not found." >&2
+    exit 1
+  fi
+  COVERAGE_ARG=(-Dsonar.python.coverage.reportPaths="$1")
+fi
+
+# A local scan analyzes the working tree on the current branch, not a pull request.
+COMMON_ARGS=(
+  -Dsonar.host.url=https://sonarcloud.io
+  -Dsonar.branch.name="$(git rev-parse --abbrev-ref HEAD)"
+  "${COVERAGE_ARG[@]}"
+)
+
+if command -v sonar-scanner >/dev/null 2>&1; then
+  exec sonar-scanner -Dsonar.token="${SONAR_TOKEN}" "${COMMON_ARGS[@]}"
+elif command -v docker >/dev/null 2>&1; then
+  exec docker run --rm \
+    -e SONAR_TOKEN="${SONAR_TOKEN}" \
+    -v "$(pwd):/usr/src" \
+    sonarsource/sonar-scanner-cli "${COMMON_ARGS[@]}"
+else
+  echo "error: neither sonar-scanner nor docker is available on PATH." >&2
+  exit 1
+fi


### PR DESCRIPTION
## What this adds

A version-controlled pre-push gate that matches CI, plus a way to run the SonarCloud scan
locally.

## Why

The pre-push gate used to live only in each developer's `.git/hooks/`, so it was neither
shared nor reproducible, and it ran mypy and pyright without the optional extras. CI installs
`--extra dev --extra mcp` before type checking, so a type annotation that references the
optional `mcp` package resolves there but not locally. The result was a local failure on code
that CI accepts (the MCP server's return type reported as unknown).

## What is in the change

- `.githooks/pre-push`: the gate, now tracked. It runs Ruff, mypy, and pyright, with the type
  checks invoked through `uv run --extra dev --extra mcp` so local matches the CI Types job.
- `scripts/install-hooks.sh`: points the clone at `.githooks/` via `core.hooksPath`.
- `scripts/sonar-local.sh`: runs the SonarCloud scan from a developer machine using the same
  project key, organization, and exclusions as CI (needs `SONAR_TOKEN`; uses the sonar-scanner
  CLI or the official Docker image).
- `CONTRIBUTING.md`: documents enabling the hook and running the local scan.

The emergency override stays `PRE_PUSH_SKIP=1 git push`.
