### PR TITLE
Guard uv.lock self-version against release drift

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,9 +8,21 @@ repos:
         args: ['--fix', '--exit-non-zero-on-fix']
       - id: ruff-format
 
+  # Local guards
+  - repo: local
+    hooks:
+      # Block uv.lock's self-version from drifting behind pyproject (release-please
+      # bumps pyproject but not the lockfile).
+      - id: lock-version
+        name: uv.lock self-version matches pyproject
+        entry: python3 scripts/check_lock_version.py --check
+        language: system
+        files: ^(pyproject\.toml|uv\.lock)$
+        pass_filenames: false
+
   # Xenon - Code complexity checker (temporarily disabled)
   # - repo: https://github.com/rubik/xenon
-  #   rev: v0.9.1  
+  #   rev: v0.9.1
   #   hooks:
   #     - id: xenon
   #       args: ['--max-absolute', 'B', '--max-modules', 'B', '--max-average', 'A']

--- a/scripts/check_lock_version.py
+++ b/scripts/check_lock_version.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Keep uv.lock's self-version in step with pyproject.
+
+release-please bumps pyproject.toml (and the conf.py / CITATION.cff / server.json
+files listed in release-please-config.json) on a release, but it does not touch
+uv.lock. The lockfile carries the project's own version in its editable
+self-package entry, so without this guard that entry drifts one release behind and
+the repo ends up with two different version numbers.
+
+Usage:
+  scripts/check_lock_version.py          # fix uv.lock to match pyproject (exit 0)
+  scripts/check_lock_version.py --check  # exit 1 if uv.lock diverges
+
+--check runs in .pre-commit-config.yaml so drift cannot land on main.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import tomllib
+
+ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = ROOT / "pyproject.toml"
+UV_LOCK = ROOT / "uv.lock"
+
+
+def _pyproject() -> dict[str, Any]:
+    with PYPROJECT.open("rb") as f:
+        return tomllib.load(f)
+
+
+def _self_version_match(text: str, name: str) -> re.Match[str] | None:
+    """Locate the editable self-package's version line in uv.lock.
+
+    Matches the project's own ``[[package]]`` entry (``name`` then ``version``),
+    not the ``{ name = ... }`` dependency references elsewhere in the lock.
+    """
+    return re.search(rf'(?m)^name = "{re.escape(name)}"\nversion = "([^"]+)"', text)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--check", action="store_true", help="Exit 1 if uv.lock diverges from pyproject."
+    )
+    args = ap.parse_args()
+
+    if not UV_LOCK.exists():
+        return 0
+
+    project = _pyproject()["project"]
+    version = str(project["version"])
+    name = str(project["name"])
+
+    text = UV_LOCK.read_text(encoding="utf-8")
+    match = _self_version_match(text, name)
+    if match is None:
+        sys.stderr.write(f"could not find the {name} self-package entry in uv.lock\n")
+        return 1
+    current = match.group(1)
+    if current == version:
+        return 0
+
+    if args.check:
+        sys.stderr.write(
+            f"uv.lock self-version {current!r} != pyproject {version!r}.\n"
+            "Run `scripts/check_lock_version.py` (or `uv lock`) to fix.\n"
+        )
+        return 1
+
+    UV_LOCK.write_text(text[: match.start(1)] + version + text[match.end(1) :], encoding="utf-8")
+    print(f"Synced uv.lock self-version to {version}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
release-please bumps pyproject.toml and the conf.py / CITATION.cff / server.json manifests on a release, but not uv.lock, whose editable self-package version then trails the released version (it had drifted to 0.3.0 behind 0.3.1 before #217 resynced it).

Adds `scripts/check_lock_version.py` (check and fix modes) wired as a local pre-commit hook, so pre-commit and pre-commit.ci block any future lockfile-version drift from landing on main.