### PR TITLE
docs: set the citation release date to the 0.4.0 release

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,6 +23,6 @@ keywords:
 license: MIT
 version: 0.4.0 # x-release-please-version
 doi: 10.5281/zenodo.8226495
-date-released: 2026-06-24
+date-released: 2026-07-03
 url: "https://github.com/astrogilda/tsbootstrap"
 repository-code: "https://github.com/astrogilda/tsbootstrap"


### PR DESCRIPTION
The version field in CITATION.cff tracks releases automatically through its marker; the date-released field does not, so it still carried the 0.3.1 date after 0.4.0 shipped. Corrected to the 0.4.0 release date.