### PR TITLE
cleanup: resolve the deferred 0.5.0 audit follow-ups (AUD-12, AUD-31, AUD-33)

### DIFF
--- a/docs/architecture/DESIGN_DECISIONS.md
+++ b/docs/architecture/DESIGN_DECISIONS.md
@@ -20,6 +20,19 @@ section), so `bootstrap` / `bootstrap_reduce` are thin registry lookups at grade
 `api.py` are the ragged-panel pair (`_coerce_panel`, above, and `bootstrap_reduce_panel`),
 whose branching mirrors the two accepted panel input forms.
 
+## Compiled module size (accepted, not split)
+
+`block/_compiled.py` is a single ~2750-line module of ~31 njit kernels. It is deliberately not
+split into key-primitives / kernels / dispatch sub-modules, for two reasons. First, its
+maintainability index is radon grade B, which is within the accepted A/B target, so there is no
+complexity trigger to act on. Second, the njit kernels are compiled with `cache=True` and call each
+other in-module; numba resolves those cross-kernel calls and inlining within one compilation unit,
+and splitting kernels across modules risks a compilation-boundary regression (lost inlining, extra
+dispatch, cache churn) for no readability gain. The one part that is genuinely reusable and
+numba-free, the counter-based key derivation, was extracted to the `prng_keys.py` reference module;
+the kernels stay put by design. Revisit only if the MI degrades past grade B or a second backend
+needs to share kernel code.
+
 ## Compiled RNG stream stability
 
 The compiled backend uses an opt-in counter-based Philox stream that is equal in distribution

--- a/src/tsbootstrap/uq/conformal.py
+++ b/src/tsbootstrap/uq/conformal.py
@@ -110,6 +110,7 @@ class EnbPIEnsemble:
     """
 
     def __init__(self) -> None:
+        """Construct an unfitted ensemble; all state is populated by :meth:`fit`."""
         self._estimators: list[_SklearnLike] | None = None
         self._oob_residuals: NDArray[np.float64] | None = None
         self._oob_pred: NDArray[np.float64] | None = None

--- a/tests/unit/test_compiled.py
+++ b/tests/unit/test_compiled.py
@@ -575,6 +575,34 @@ def _numpy_block_lengths_from_executor(executor, spec, n, seed, B):
     return lengths
 
 
+# One entry per reduce-path method; the thread-count determinism guarantee is identical for every
+# spec, so it is parametrized here rather than copied into each family class below.
+_REDUCE_DETERMINISM_SPECS = [
+    ("iid", IID()),
+    ("moving", MovingBlock(block_length=12)),
+    ("circular", CircularBlock(block_length=12)),
+    ("non_overlapping", NonOverlappingBlock(block_length=12)),
+]
+
+
+@pytest.mark.parametrize(
+    "spec", [s for _, s in _REDUCE_DETERMINISM_SPECS], ids=[n for n, _ in _REDUCE_DETERMINISM_SPECS]
+)
+def test_reduce_determinism_across_thread_counts(spec):
+    n, B = 600, 2500
+    data = np.ascontiguousarray(np.random.default_rng(0).standard_normal((n, 2)))
+    root_key = _root(7)
+    max_threads = numba.config.NUMBA_NUM_THREADS
+    numba.set_num_threads(max_threads)
+    out_many = sk.compiled_reduce(spec, data, root_key, n_bootstraps=B)
+    try:
+        numba.set_num_threads(1)
+        out_one = sk.compiled_reduce(spec, data, root_key, n_bootstraps=B)
+    finally:
+        numba.set_num_threads(max_threads)
+    np.testing.assert_array_equal(out_one, out_many)
+
+
 class TestIIDCompiled:
     def test_statistic_matches_pure_numpy_path(self):
         n, B = 500, 4000
@@ -590,20 +618,6 @@ class TestIIDCompiled:
 
         ks = ks_2samp(ker, ref)
         assert ks.pvalue > 0.01, f"IID statistic KS rejected: p={ks.pvalue:.4f}"
-
-    def test_determinism_across_thread_counts(self):
-        n, B = 600, 2500
-        data = np.ascontiguousarray(np.random.default_rng(0).standard_normal((n, 2)))
-        root_key = _root(7)
-        max_threads = numba.config.NUMBA_NUM_THREADS
-        numba.set_num_threads(max_threads)
-        out_many = sk.compiled_reduce(IID(), data, root_key, n_bootstraps=B)
-        try:
-            numba.set_num_threads(1)
-            out_one = sk.compiled_reduce(IID(), data, root_key, n_bootstraps=B)
-        finally:
-            numba.set_num_threads(max_threads)
-        np.testing.assert_array_equal(out_one, out_many)
 
     def test_shape_dtype_and_sim_dtype(self):
         x = np.random.default_rng(0).standard_normal(200)
@@ -639,21 +653,6 @@ class TestMovingBlockCompiled:
         ref = _numpy_block_stat(_moving, spec, data, seed=123, B=B)
         ks = ks_2samp(ker, ref)
         assert ks.pvalue > 0.01, f"moving statistic KS rejected: p={ks.pvalue:.4f}"
-
-    def test_determinism_across_thread_counts(self):
-        n, length, B = 600, 12, 2500
-        data = np.ascontiguousarray(np.random.default_rng(0).standard_normal((n, 2)))
-        spec = MovingBlock(block_length=length)
-        root_key = _root(7)
-        max_threads = numba.config.NUMBA_NUM_THREADS
-        numba.set_num_threads(max_threads)
-        out_many = sk.compiled_reduce(spec, data, root_key, n_bootstraps=B)
-        try:
-            numba.set_num_threads(1)
-            out_one = sk.compiled_reduce(spec, data, root_key, n_bootstraps=B)
-        finally:
-            numba.set_num_threads(max_threads)
-        np.testing.assert_array_equal(out_one, out_many)
 
     def test_shape_dtype_and_sim_dtype(self):
         x = np.random.default_rng(0).standard_normal(200)
@@ -691,21 +690,6 @@ class TestCircularBlockCompiled:
         ks = ks_2samp(ker, ref)
         assert ks.pvalue > 0.01, f"circular statistic KS rejected: p={ks.pvalue:.4f}"
 
-    def test_determinism_across_thread_counts(self):
-        n, length, B = 600, 12, 2500
-        data = np.ascontiguousarray(np.random.default_rng(0).standard_normal((n, 2)))
-        spec = CircularBlock(block_length=length)
-        root_key = _root(7)
-        max_threads = numba.config.NUMBA_NUM_THREADS
-        numba.set_num_threads(max_threads)
-        out_many = sk.compiled_reduce(spec, data, root_key, n_bootstraps=B)
-        try:
-            numba.set_num_threads(1)
-            out_one = sk.compiled_reduce(spec, data, root_key, n_bootstraps=B)
-        finally:
-            numba.set_num_threads(max_threads)
-        np.testing.assert_array_equal(out_one, out_many)
-
     def test_shape_dtype_and_sim_dtype(self):
         x = np.random.default_rng(0).standard_normal(200)
         spec = CircularBlock(block_length=8)
@@ -730,21 +714,6 @@ class TestNonOverlappingBlockCompiled:
         ref = _numpy_block_stat(_non_overlapping, spec, data, seed=123, B=B)
         ks = ks_2samp(ker, ref)
         assert ks.pvalue > 0.01, f"non-overlapping statistic KS rejected: p={ks.pvalue:.4f}"
-
-    def test_determinism_across_thread_counts(self):
-        n, length, B = 600, 12, 2500
-        data = np.ascontiguousarray(np.random.default_rng(0).standard_normal((n, 2)))
-        spec = NonOverlappingBlock(block_length=length)
-        root_key = _root(7)
-        max_threads = numba.config.NUMBA_NUM_THREADS
-        numba.set_num_threads(max_threads)
-        out_many = sk.compiled_reduce(spec, data, root_key, n_bootstraps=B)
-        try:
-            numba.set_num_threads(1)
-            out_one = sk.compiled_reduce(spec, data, root_key, n_bootstraps=B)
-        finally:
-            numba.set_num_threads(max_threads)
-        np.testing.assert_array_equal(out_one, out_many)
 
     def test_shape_and_sim_dtype(self):
         xv = np.random.default_rng(1).standard_normal((300, 4))


### PR DESCRIPTION
## Summary

Closes out the three audit findings that the 0.5.0 remediation left open, resolving each at its root rather than carrying them as deferred items.

## What changed

- **AUD-33 (docstring):** `EnbPIEnsemble.__init__` was the module's only interrogate miss. Added a one-line docstring; interrogate on `conformal.py` is now 100 percent.
- **AUD-31 (test duplication):** the thread-count determinism test was copied verbatim into each of the four block-family test classes, differing only by spec. Collapsed the four copies into one parametrized test over the spec list, matching the existing compiled-values parametrization in the same file. The family-specific statistic and block-length tests stay per class. Net minus 31 lines with identical coverage.
- **AUD-12 (module size):** recorded the deliberate decision NOT to split the compiled block module in `docs/architecture/DESIGN_DECISIONS.md`. Its maintainability index is within the accepted grade band, and its cache-enabled njit kernels cross-call within one numba compilation unit, so splitting them across modules would risk an inlining and cache regression for no readability gain. The reusable numba-free part (key derivation) was already extracted to `prng_keys.py`.

## Verification

- Full unit and property suite green.
- `_NUMPY_BITS` byte-freeze green (the docstring change is behavior-neutral).
- ruff, format, interrogate, and no-dash checks clean.
