### PR TITLE
fix(deps): bump mistune to 3.3.3 for the parse_link_text DoS advisory

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2269,14 +2269,14 @@ wheels = [
 
 [[package]]
 name = "mistune"
-version = "3.2.1"
+version = "3.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/84/620cc3f7e3adf6f5067e10f4dbae71295d8f9e16d5d3f9ef97c40f2f592c/mistune-3.2.1.tar.gz", hash = "sha256:7c8e5501d38bac1582e067e46c8343f17d57ea1aaa735823f3aba1fd59c88a28", size = 98003, upload-time = "2026-05-03T14:33:22.312Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/a5/2dab368d6950e6808904dec98f54c7e726ee7be4a0c6afe00e6e011bd52d/mistune-3.3.3.tar.gz", hash = "sha256:c4c6c0c840b8637a2e9b8b6d607eb7c8f00888bf14c754409bcd339e848c2477", size = 115363, upload-time = "2026-07-09T06:18:05.268Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/7f/a946aa4f8752b37102b41e64dca18a1976ac705c3a0d1dfe74d820a02552/mistune-3.2.1-py3-none-any.whl", hash = "sha256:78cdb0ba5e938053ccf63651b352508d2efa9411dc8810bfb05f2dc5140c0048", size = 53749, upload-time = "2026-05-03T14:33:20.551Z" },
+    { url = "https://files.pythonhosted.org/packages/89/70/b1e4737b84163db5bb1dfde6f216dbfbf32783330a9989c965e121172830/mistune-3.3.3-py3-none-any.whl", hash = "sha256:99de1585e42dcbd826faa9e11a202727a5e202e4e4722a4c69ac1ff615793dd7", size = 63569, upload-time = "2026-07-09T06:18:03.839Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Dependabot alert 26 flags mistune below 3.3.0 (GHSA-qcq2-496w-v96p, CVE-2026-49851, high severity): quadratic-time parsing of repeated bracket characters in parse_link_text lets a ~6 KB payload block a CPU for seconds.

The dependency is transitive (jupyter -> nbconvert -> mistune) through the examples and docs extras, so no runtime code path in the library itself renders untrusted Markdown; the bump is still warranted to clear the locked environment.

Change: uv.lock resolves mistune 3.2.1 -> 3.3.3. Verified locally: nbconvert 7.17.1 imports cleanly against 3.3.3, and the advisory proof-of-concept (6400 repeated brackets) parses in 0.15 seconds.