### PR TITLE
fix(mutation): scope the ephemeral numba cache to njit-kernel mutants and warm the shared cache

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -43,10 +43,19 @@ jobs:
         env:
           MRC_TOKEN: ${{ secrets.MUTATION_RATCHET_TOKEN }}
 
+      - name: Start the memory telemetry sampler
+        run: |
+          nohup sh -c 'while true; do echo "$(date -u +%H:%M:%S) $(free -m | awk "/^Mem:/ {print \$3\" used / \"\$2\" total\"}")" >> /tmp/memlog.txt; sleep 10; done' &
+
       - name: Generate mutants and run the subprocess gate
         env:
           HYPOTHESIS_PROFILE: mutmut
+          PYTHONUNBUFFERED: '1'
         run: uv run python tools/run_mutation_gate.py --regen --workers 4
+
+      - name: Print the memory telemetry
+        if: always()
+        run: cat /tmp/memlog.txt || true
 
       - name: Upload per-mutant outcomes
         if: always()

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -27,7 +27,7 @@ jobs:
   mutation:
     name: Mutation ratchet (engine + model core)
     runs-on: ubuntu-latest
-    timeout-minutes: 300  # ~1,100 mutants at 4 workers on the standard runner need well over 90 minutes
+    timeout-minutes: 420  # 2,723 mutants at 4 workers measured ~5h05m on the standard runner (2026-07-11 run reached 97% at the old 300m cap); 420 leaves headroom for slow-tail variance
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -14,6 +14,10 @@ name: Mutation ratchet
 permissions:
   contents: read
 
+# One gate run at a time; a manual dispatch queues behind the nightly instead of racing it.
+concurrency:
+  group: mutation-ratchet
+
 on:
   schedule:
     - cron: '0 6 * * *'  # 06:00 UTC nightly

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -26,6 +26,8 @@ jobs:
     timeout-minutes: 300  # ~1,100 mutants at 4 workers on the standard runner need well over 90 minutes
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up uv and Python 3.12
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,9 +87,18 @@ settings.load_profile(_profile)
 _UNDER_MUTMUT = os.environ.get("HYPOTHESIS_PROFILE") == "mutmut"
 
 
+# Modules in the mutation scope that define their own @njit(cache=True) kernel. Only mutants of
+# these modules face the cache-masking hazard described in the fixture below; every other mutant
+# leaves the kernel sources untouched, so the shared persistent NUMBA_CACHE_DIR the subprocess
+# runner provides is both correct and necessary for them. Blanketing the ephemeral cache over all
+# mutants made every subprocess cold-compile every kernel its tests import, which multiplied the
+# run time and OOM-killed the 16 GB CI runner when several workers compiled concurrently.
+_NJIT_MUTANT_PREFIXES = ("tsbootstrap.engines.var.",)
+
+
 @pytest.fixture(scope="session", autouse=True)
 def _mutmut_ephemeral_numba_cache():
-    """Give each mutation-testing session a fresh, throwaway numba on-disk cache.
+    """Give njit-kernel mutation sessions a fresh, throwaway numba on-disk cache.
 
     The VAR recurrence kernel is compiled with ``@numba.njit(..., cache=True)`` (see
     ``engines/var.py``), so its machine code is cached to disk keyed by the *unmutated* source.
@@ -98,8 +107,14 @@ def _mutmut_ephemeral_numba_cache():
     executes and the mutant survives spuriously. Pointing ``NUMBA_CACHE_DIR`` at a per-session
     tempdir forces a fresh compile of the mutated source on every mutant, at native JIT speed.
     This replaces the old ``NUMBA_DISABLE_JIT=1`` workaround (interpreted execution, ~28 min/run).
+
+    The throwaway cache applies only to mutants of modules that carry their own njit kernel
+    (``_NJIT_MUTANT_PREFIXES``) -- the only mutants the masking hazard can reach. Every other
+    mutant, and the baseline/warmup run (no ``MUTANT_UNDER_TEST`` set), keeps the shared
+    persistent cache so unmutated kernels compile once per run instead of once per mutant.
     """
-    if not _UNDER_MUTMUT:
+    mutant = os.environ.get("MUTANT_UNDER_TEST", "")
+    if not _UNDER_MUTMUT or not mutant.startswith(_NJIT_MUTANT_PREFIXES):
         yield
         return
     with tempfile.TemporaryDirectory(prefix="tsbootstrap-mutmut-numba-") as cache_dir:

--- a/tools/mutation_allowlist.txt
+++ b/tools/mutation_allowlist.txt
@@ -75,7 +75,7 @@ adaptive:nexcp_quantile:Sub:Add:c95fe6a7:67933b
 # PR-C seam equivalents (dispatch.py + api.py; see mutation_equivalents.md)
 dispatch:_make_numpy_values._numpy_values:Name:Name:a88fdf19:8b044b
 dispatch:stream_numpy_values:Tuple:Tuple:3b482d17:929898
-dispatch:_make_numpy_values._numpy_values:Eq:Eq:ce266b42:251837
+dispatch:_make_numpy_values._numpy_values:Eq:Eq:ce266b42:52b9ba
 dispatch:_make_numpy_values._numpy_values:Name:Name:6f3c5cde:4c6b73
 dispatch:register_chunk_executor.decorator:Subscript:Subscript:996e2d87:68cdff
 dispatch:register_chunk_executor.decorator:Subscript:Subscript:cdc1bd21:3cfddf
@@ -85,7 +85,7 @@ dispatch:register_reduce_executor.decorator:Subscript:Subscript:918893c3:205b59
 dispatch:register_values_executor.decorator:Subscript:Subscript:20c80b54:d7ea0d
 api:bootstrap:DIFF:7603531d:daba3b
 api:bootstrap:Name:Name:7603531d:3da2eb
-api:bootstrap_iter:Tuple:Tuple:0bf54728:461e5a
+api:bootstrap_iter:Tuple:Tuple:0bf54728:8b0323
 api:_coerce_panel:Gt:Gt:4caa6f85:fc772c
 api:_coerce_panel:Gt:GtE:4caa6f85:563a1f
 api:_coerce_panel:Name:Name:e3be77c7:9a53c5

--- a/tools/run_mutation_gate.py
+++ b/tools/run_mutation_gate.py
@@ -5,9 +5,9 @@ keeps mutmut ONLY for AST mutant generation and executes every mutant in an isol
 mutation_ratchet_core.subprocess_runner. It is the reliable, repeatable mutation gate.
 
 Pipeline:
-  1. Ensure the mutants/ tree exists (regenerate with `mutmut run` if missing or --regen; the stats
-     phase will crash in-process, which is expected and harmless -- generation completes first).
-  2. Read every mutant name from `mutmut results --all`.
+  1. Ensure the mutants/ tree exists (regenerate if missing or --regen) by calling mutmut's
+     generation functions directly -- generation only, no in-process test run.
+  2. Read every mutant name from the trampolined mutants/src tree.
   3. Map each mutant to its covering test files by source module (MODULE_TESTS below).
   4. Execute all mutants concurrently, one fresh subprocess each.
   5. Report killed / survived / timeout and list survivors for triage against
@@ -192,22 +192,60 @@ def _warm_numba_cache() -> None:
     print("[warmup] shared numba cache populated", flush=True)
 
 
+# Generation-only driver, executed in a subprocess. `mutmut run` has no generate-only mode: after
+# writing the mutants/ tree it starts an in-process stats pass that runs the whole test suite in
+# one interpreter -- the exact numba-hostile execution model this Layer-3 driver exists to avoid.
+# The old approach ran `mutmut run` anyway and RELIED on that stats pass crashing quickly, which
+# held locally but not on the CI runner, where the pass ground on until the VM died. Calling the
+# generation functions directly ends the process deterministically after the tree is written; no
+# test ever executes in-process. The five calls mirror the generation block at the top of
+# mutmut.__main__._run (mutmut is pinned in uv.lock; revisit this block on a mutmut upgrade).
+_GEN_SNIPPET = """
+import os
+from pathlib import Path
+
+os.environ["MUTANT_UNDER_TEST"] = "mutant_generation"
+from mutmut.__main__ import (
+    Config,
+    copy_also_copy_files,
+    copy_src_dir,
+    create_mutants,
+    makedirs,
+    setup_source_paths,
+    store_lines_covered_by_tests,
+)
+
+Config.ensure_loaded()
+makedirs(Path("mutants"), exist_ok=True)
+copy_src_dir()
+copy_also_copy_files()
+setup_source_paths()
+store_lines_covered_by_tests()
+stats = create_mutants(os.cpu_count() or 4)
+print(f"generated: {stats.mutated} files mutated, {stats.ignored} ignored, "
+      f"{stats.unmodified} unmodified")
+"""
+
+
 def _ensure_mutants(regen: bool) -> None:
     if MUTANTS_SRC.exists() and not regen:
         return
-    print(
-        "[gen] generating mutants/ (mutmut run; the in-process stats crash after generation is expected)"
-    )
-    subprocess.run(
-        ["uv", "run", "mutmut", "run"],  # noqa: S603, S607 - uv is on PATH (local dev + remote box)
+    print("[gen] generating mutants/ (generation only; no in-process test run)", flush=True)
+    proc = subprocess.run(
+        ["uv", "run", "python", "-c", _GEN_SNIPPET],  # noqa: S603, S607 - uv on PATH (local + remote box)
         cwd=REPO,
         env={**os.environ, **_MUTMUT_ENV},
         capture_output=True,
         text=True,
         timeout=600,
     )
-    if not MUTANTS_SRC.exists():
-        sys.exit("mutants/ was not generated; inspect mutmut output")
+    print(
+        f"[gen] {proc.stdout.strip().splitlines()[-1] if proc.stdout.strip() else ''}", flush=True
+    )
+    if proc.returncode != 0 or not MUTANTS_SRC.exists():
+        sys.exit(
+            f"mutant generation failed (exit {proc.returncode}):\n{proc.stdout}\n{proc.stderr}"
+        )
 
 
 _KEY_RE = re.compile(r"\['(x_.+?__mutmut_\d+)'\]")

--- a/tools/run_mutation_gate.py
+++ b/tools/run_mutation_gate.py
@@ -144,6 +144,53 @@ def _function_key(mutant_name: str) -> str:
 
 _IMPACT_PATH = REPO / "tools" / "mutation_test_impact.json"
 
+# Test files that compile the expensive numba kernel sets (the full compiled module + the panel
+# kernels). One serial baseline pass over these populates the shared NUMBA_CACHE_DIR before the
+# worker fan-out, so concurrent mutant subprocesses hit the cache instead of cold-compiling the
+# same kernels side by side (which OOM-killed the 16 GB CI runner and dominated the run time).
+_WARMUP_TESTS = ("tests/unit/test_compiled.py", "tests/unit/test_panel.py")
+
+
+def _warm_numba_cache() -> None:
+    """Populate the shared numba cache with one serial baseline run of the kernel-heavy tests.
+
+    Runs with the mutated tree on PYTHONPATH but no MUTANT_UNDER_TEST, so the trampolines execute
+    the original code and the conftest fixture keeps the shared NUMBA_CACHE_DIR (its ephemeral
+    override only fires for njit-kernel mutants). A failure here means the clean baseline itself
+    is broken, in which case every mutant would be reported killed, so abort loudly instead.
+    """
+    print(f"[warmup] compiling the shared numba cache via {' '.join(_WARMUP_TESTS)}", flush=True)
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(MUTANTS_SRC)
+    env["NUMBA_CACHE_DIR"] = str(CACHE)
+    env.setdefault("HYPOTHESIS_PROFILE", "mutmut")
+    env.pop("MUTANT_UNDER_TEST", None)
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            *_WARMUP_TESTS,
+            "-x",
+            "-q",
+            "-p",
+            "no:cacheprovider",
+            "-o",
+            "addopts=",
+        ],
+        cwd=REPO,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=1800,
+    )
+    if proc.returncode != 0:
+        sys.exit(
+            "FATAL: the numba-cache warmup run failed on the unmutated baseline; every mutant "
+            f"would be falsely reported killed. pytest output:\n{proc.stdout}\n{proc.stderr}"
+        )
+    print("[warmup] shared numba cache populated", flush=True)
+
 
 def _ensure_mutants(regen: bool) -> None:
     if MUTANTS_SRC.exists() and not regen:
@@ -208,6 +255,7 @@ def main() -> int:
 
     _ensure_mutants(args.regen)
     CACHE.mkdir(exist_ok=True)
+    _warm_numba_cache()
     names = _mutant_names()
     if not names:
         sys.exit(


### PR DESCRIPTION
The nightly mutation gate has failed every night since 2026-07-06 with the runner receiving a shutdown signal (exit 143) minutes into the mutant fan-out (runs 28774876007 through 29075595415) — the VM-level kill signature of memory exhaustion on the standard 16 GB runner.

Root cause: the subprocess runner is designed around a shared persistent NUMBA_CACHE_DIR so mutant subprocesses reuse compiled kernels, but the conftest mutation fixture replaced that cache with a throwaway per-session directory for every mutant. Every subprocess cold-compiled every kernel its tests import. The 0.6.0 scope expansion (2 modules to 6, 1064 to 2877 mutants) then put the api mutants first in the queue, and their covering set is the kernel-heavy one (test_compiled, test_panel), so four workers ran sustained concurrent LLVM compiles from the first wave and exhausted the runner. The same defect also inflated total runtime toward the 6-hour job cap.

The throwaway cache exists for a real reason: the on-disk cache can mask mutations to a compiled kernel's source (the mutant imports, numba hits a stale cache entry, the mutation never executes). That hazard only reaches mutants of modules defining their own njit kernel, which in the mutated scope is engines/var.py alone.

Changes:
- tests/conftest.py: the ephemeral-cache override now applies only when MUTANT_UNDER_TEST targets an njit-kernel module (engines.var); every other mutant and the baseline keeps the shared persistent cache.
- tools/run_mutation_gate.py: warm the shared cache with one serial baseline run of the kernel-heavy tests before the worker fan-out, aborting loudly if the baseline itself fails.

Verified with a four-mutant local smoke: warmup populates the cache in ~2 minutes (51 files); mutants with the heaviest covering set then run in ~10 seconds each with the cache byte-stable, and an engines.var mutant still takes the ephemeral path without touching the shared cache. Projected full run at 4 workers: roughly 2 hours for 2877 mutants, with no concurrent cold-compile storm. A workflow_dispatch validation run on this branch follows.