### PR TITLE
feat(security): scan the lockfile against OSV on pull requests and weekly

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,0 +1,46 @@
+name: OSV-Scanner
+
+# Two complementary scans of the locked dependency graph against the OSV database
+# (CVEs plus MAL- malicious-package records):
+#   - Pull requests: diff mode. Compares base and head branches and fails only when the
+#     PR introduces a NEW vulnerability, so pre-existing or unfixable transitive findings
+#     never block unrelated work.
+#   - Weekly schedule + pushes to main: full scan of uv.lock, uploaded as SARIF to the
+#     Security tab (Code Scanning) rather than failing the build, so a new advisory
+#     against an unchanged lockfile surfaces as an alert instead of a red default branch.
+# Suppressions, whenever needed, live in osv-scanner.toml next to uv.lock, each with a
+# reason and an ignoreUntil expiry.
+permissions: {}
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: '30 5 * * 1' # 05:30 UTC Monday
+  workflow_dispatch: {}
+
+jobs:
+  scan-pr:
+    if: github.event_name == 'pull_request'
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    with:
+      scan-args: |-
+        --lockfile=./uv.lock
+
+  scan-scheduled:
+    if: github.event_name != 'pull_request'
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    with:
+      scan-args: |-
+        --lockfile=./uv.lock
+      fail-on-vuln: false

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -26,9 +26,9 @@ jobs:
     if: github.event_name == 'pull_request'
     uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
     permissions:
-      security-events: write
-      contents: read
-      actions: read
+      security-events: write # upload SARIF to code scanning
+      contents: read # checkout for the lockfile scan
+      actions: read # the reusable workflow reads workflow metadata
     with:
       scan-args: |-
         --lockfile=./uv.lock
@@ -37,9 +37,9 @@ jobs:
     if: github.event_name != 'pull_request'
     uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
     permissions:
-      security-events: write
-      contents: read
-      actions: read
+      security-events: write # upload SARIF to code scanning
+      contents: read # checkout for the lockfile scan
+      actions: read # the reusable workflow reads workflow metadata
     with:
       scan-args: |-
         --lockfile=./uv.lock


### PR DESCRIPTION
Companion to #240/#241. Adds an OSV-Scanner workflow over uv.lock with the two reusable workflows from google/osv-scanner-action (pinned to the v2.3.8 commit):

- Pull requests: diff mode — compares base and head and fails only on newly introduced vulnerabilities, so pre-existing or unfixable transitive findings cannot block unrelated PRs.
- Weekly schedule + pushes to main: full scan uploaded as SARIF to the Security tab (fail-on-vuln false), so a new advisory published against an unchanged lockfile becomes a Code Scanning alert rather than a red default branch.

OSV includes MAL- malicious-package records alongside CVEs, adding known-malware coverage on top of Dependabot's advisory feed. Future suppressions go in osv-scanner.toml with a reason and an ignoreUntil expiry; none are needed today (uv audit reports the current lock clean).