### PR TITLE
fix(ci): drop persisted checkout credentials, disable the release cache, and add the malware check

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,5 +1,10 @@
 name: CI
 
+# Cancel superseded runs of the same branch or pull request.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   UV_MALWARE_CHECK: '1' # abort any uv resolution that hits an OSV malicious-package record
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,5 +1,8 @@
 name: CI
 
+env:
+  UV_MALWARE_CHECK: '1' # abort any uv resolution that hits an OSV malicious-package record
+
 # Minimal permissions following the principle of least privilege
 permissions:
   contents: read
@@ -35,6 +38,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up uv and Python 3.11
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
@@ -57,6 +62,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up uv and Python 3.12
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
@@ -90,6 +97,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Set up uv and Python ${{ matrix.python-version }}
@@ -136,6 +144,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Set up uv and Python 3.12
@@ -171,6 +180,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up uv and Python 3.11
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
@@ -191,6 +202,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Set up uv and Python 3.11

--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -1,5 +1,8 @@
 name: Publish to MCP Registry
 
+env:
+  UV_MALWARE_CHECK: '1' # abort any uv resolution that hits an OSV malicious-package record
+
 # Publishes server.json to the official MCP registry once the PyPI package for the
 # tag is available. Authenticates with GitHub OIDC (no stored secrets); the registry
 # verifies ownership via the io.github.astrogilda/* namespace and the mcp-name marker
@@ -20,6 +23,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install mcp-publisher
         run: |

--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -8,6 +8,12 @@ env:
 # verifies ownership via the io.github.astrogilda/* namespace and the mcp-name marker
 # in the package README. The PyPI release itself is handled by release.yml.
 
+permissions: {}
+
+# Serialize publishes; never cancel one mid-flight.
+concurrency:
+  group: mcp-publish
+
 on:
   release:
     types: [published]
@@ -18,8 +24,8 @@ jobs:
     name: Publish server.json to the MCP registry
     runs-on: ubuntu-latest
     permissions:
-      id-token: write  # required for GitHub OIDC authentication
-      contents: read
+      id-token: write # the registry authenticates this workflow via GitHub OIDC
+      contents: read # checkout of server.json and the version stamp
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,14 +11,19 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
+
+# Serialize per branch; never cancel an in-flight release PR update.
+concurrency:
+  group: release-please-${{ github.ref }}
 
 jobs:
   release-please:
     name: Maintain the release pull request
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # zizmor: ignore[excessive-permissions] release-please tags commits and publishes the GitHub Release
+      pull-requests: write # zizmor: ignore[excessive-permissions] release-please maintains the rolling release pull request
     steps:
       - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,7 @@ on:
 # Least-privilege default; the publish job alone adds id-token for OIDC. The release
 # path also runs with the uv cache disabled (a poisoned cache restored into the build
 # job could reach the published artifacts) and with checkout credentials dropped.
-permissions:
-  contents: read
+permissions: {}
 
 # Serialize wheel builds and uploads; never cancel a publish mid-flight.
 concurrency:
@@ -21,6 +20,8 @@ jobs:
   build_wheels:
     name: Build wheels
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -48,6 +49,8 @@ jobs:
     needs: build_wheels
     name: Test wheels on ${{ matrix.os }} with ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read # checkout
     strategy:
       fail-fast: false  # to not fail all combinations if just one fail
       matrix:
@@ -87,6 +90,8 @@ jobs:
     needs: build_wheels
     name: Test wheels on ${{ matrix.os }} with ${{ matrix.python-version }}
     runs-on: windows-latest
+    permissions:
+      contents: read # checkout
     strategy:
       fail-fast: false  # to not fail all combinations if just one fail
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,10 @@ on:
 permissions:
   contents: read
 
+# Serialize wheel builds and uploads; never cancel a publish mid-flight.
+concurrency:
+  group: release
+
 jobs:
   build_wheels:
     name: Build wheels
@@ -127,7 +131,7 @@ jobs:
     # PYPI_TOKEN secret) is needed. attestations: true emits PEP 740
     # provenance for the uploaded distributions.
     permissions:
-      id-token: write
+      id-token: write # PyPI trusted publishing verifies the workflow identity via OIDC
 
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,17 @@
 name: Build wheels and publish to PyPI
 
+env:
+  UV_MALWARE_CHECK: '1' # abort any uv resolution that hits an OSV malicious-package record
+
 on:
   release:
     types: [published]
+
+# Least-privilege default; the publish job alone adds id-token for OIDC. The release
+# path also runs with the uv cache disabled (a poisoned cache restored into the build
+# job could reach the published artifacts) and with checkout credentials dropped.
+permissions:
+  contents: read
 
 jobs:
   build_wheels:
@@ -11,11 +20,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up uv and Python 3.10
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          enable-cache: true
+          enable-cache: false
           python-version: '3.10'
 
       - name: Build wheel and sdist
@@ -41,10 +52,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Set up uv and Python ${{ matrix.python-version }}
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          enable-cache: true
+          enable-cache: false
           python-version: ${{ matrix.python-version }}
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -61,7 +74,7 @@ jobs:
       - name: Install wheel and extras into a fresh venv
         run: |
           uv venv
-          uv pip install "${{ env.WHEELNAME }}[dev]"
+          uv pip install "${WHEELNAME}[dev]"
 
       - name: Run tests
         run: uv run --no-project python -m pytest tests/
@@ -78,10 +91,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Set up uv and Python ${{ matrix.python-version }}
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          enable-cache: true
+          enable-cache: false
           python-version: ${{ matrix.python-version }}
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4


### PR DESCRIPTION
Companion to #240-#243; closes out a zizmor audit of the workflows (zizmor now reports zero findings on these files).

- artipacked (15 findings): every checkout now sets persist-credentials: false. The default persists a repo-scoped token in .git where later steps or uploaded artifacts can leak it; no workflow pushes from its checkout.
- cache-poisoning (3 findings, release.yml): setup-uv caching disabled on the wheel-build and wheel-test jobs — a poisoned cache restored into the release path could reach the artifacts published to PyPI.
- excessive-permissions (4 findings, release.yml): top-level contents: read; the publish job keeps only its OIDC id-token: write.
- template-injection (1 finding, release.yml): the wheel install now uses the runtime $WHEELNAME env var instead of interpolating ${{ env.WHEELNAME }} into the script.
- SEC hardening: UV_MALWARE_CHECK=1 on CI, release, and MCP-publish, so any uv resolution that hits an OSV malicious-package record aborts before download (verified working on uv 0.11.28).

The one remaining zizmor finding (mutation.yml checkout) is fixed on the open #238 branch to avoid a cross-PR conflict on that file.