### PR TITLE
docs: link the three companion articles from the README and docs index

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,13 @@
 
 1. [🚀 Getting Started](#-getting-started)
 2. [⚡ Performance](#-performance)
-3. [🧩 Modules](#-modules)
-4. [🗺 Roadmap](#-roadmap)
-5. [🤝 Contributing](#-contributing)
-6. [📄 License](#-license)
-7. [📍 Time Series Bootstrapping Methods intro](#time-series-bootstrapping)
-8. [👏 Contributors](#-contributors)
+3. [📚 Articles](#-articles)
+4. [🧩 Modules](#-modules)
+5. [🗺 Roadmap](#-roadmap)
+6. [🤝 Contributing](#-contributing)
+7. [📄 License](#-license)
+8. [📍 Time Series Bootstrapping Methods intro](#time-series-bootstrapping)
+9. [👏 Contributors](#-contributors)
 
 
 
@@ -210,6 +211,19 @@ uv add "tsbootstrap[accel]"
 # or
 pip install "tsbootstrap[accel]"
 ```
+
+## 📚 Articles
+
+Deep dives on the statistics and engineering behind the library, with worked
+examples and animations:
+
+- [Your bootstrap is lying to you](https://thepragmaticquant.com/your-bootstrap-is-lying-to-you/):
+  why the ordinary i.i.d. bootstrap collapses on autocorrelated data (a nominal 90%
+  interval that covers 49.6% of the time) and how block resampling repairs it.
+- [When your errors aren't equal](https://thepragmaticquant.com/when-your-errors-arent-equal/):
+  the wild bootstrap for heteroskedastic errors, and what a block-wild variant preserves.
+- [Count the bytes, not the FLOPs](https://thepragmaticquant.com/why-we-stopped-materializing-arrays/):
+  the memory-wall engineering behind the compiled backend, with hardware-counter receipts.
 
 ## 🧩 Modules
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -37,6 +37,20 @@ with a method specification object.
 
    tutorials/index
 
+Articles
+--------
+
+Deep dives on the statistics and engineering behind the library, with worked
+examples and animations:
+
+- `Your bootstrap is lying to you <https://thepragmaticquant.com/your-bootstrap-is-lying-to-you/>`_:
+  why the ordinary i.i.d. bootstrap collapses on autocorrelated data and how block
+  resampling repairs it.
+- `When your errors aren't equal <https://thepragmaticquant.com/when-your-errors-arent-equal/>`_:
+  the wild bootstrap for heteroskedastic errors.
+- `Count the bytes, not the FLOPs <https://thepragmaticquant.com/why-we-stopped-materializing-arrays/>`_:
+  the memory-wall engineering behind the compiled backend.
+
 .. toctree::
    :maxdepth: 2
    :caption: API reference


### PR DESCRIPTION
Adds an Articles section to the README (will surface on PyPI at the next release) and to the Sphinx docs index, linking the three published deep dives:

- Your bootstrap is lying to you (block bootstrap)
- When your errors aren't equal (wild bootstrap)
- Count the bytes, not the FLOPs (compiled backend memory engineering)

All three URLs verified live (HTTP 200). The arXiv badge already points at the current software paper (2607.06690, now public), so no change needed there.