### PR TITLE
docs: correct panel API references and add panel benchmark results

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,12 @@ reduce holds about 20 MB at B=50000 where materializing every replicate takes
 about 1.94 GB (roughly 96x lighter), from
 [`benchmarks/results/membench_2026-07-04.json`](benchmarks/results/membench_2026-07-04.json).
 The multivariate and ragged-panel reduce
-paths have no equivalent in `arch`. Full methodology,
+paths have no equivalent in `arch`. The panel reduce
+(`bootstrap_reduce_panel`) returns the full per-series bootstrap distribution
+of the statistic (`n_bootstraps x num_series`), so quantile and tail workflows
+on an estimator are served directly with no replicate tensor. Use the
+materializing path only when the workflow consumes the resampled paths
+themselves. Full methodology,
 single-threaded numbers, and the reproduction script are in
 [benchmarks/README.md](benchmarks/README.md).
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -7,6 +7,9 @@ residual bootstrap engines (`bench_bootstrap.py`), both runnable as
 [airspeed velocity](https://asv.readthedocs.io/en/stable/) (asv) benchmark
 suites or as plain Python scripts.
 
+Every multiplier in this file names, in the same sentence, the baseline it was
+measured against and the axis (time or memory) it lives on.
+
 ---
 
 ## Contents
@@ -143,10 +146,43 @@ machine). These figures are read from `results/membench_2026-07-04.json`:
 
 ### Panel-scale reduce
 
-`bootstrap_reduce` accepts a list of ragged series and bootstraps the entire
-panel in one pass, fusing the work over all series without materializing the
-full panel tensor, so peak memory tracks the statistic output rather than the
-replicate count. Re-run the panel benchmark on your machine for exact figures.
+`bootstrap_reduce_panel` bootstraps an entire panel of series in one pass,
+fusing the work over all series without materializing the full panel tensor,
+so peak memory tracks the statistic output rather than the replicate count.
+It accepts two input forms: a list of unequal-length 1-D arrays, or a single
+flat values array paired with CSR-style offsets (`indptr`).
+
+The reduce returns the full per-series bootstrap distribution of the statistic
+(`n_bootstraps x num_series`), so quantile and tail workflows on an estimator
+are served directly with no replicate tensor. Use the materializing path only
+when the workflow consumes the resampled paths themselves.
+
+Three ways to compute the same per-series statistics on one panel, at three
+panel sizes (AR(1) panel, n=200 observations per series, MovingBlock with
+block_length=20, statistic mean, B=1000 replicates):
+
+- **fused `bootstrap_reduce_panel`** with `backend="compiled"`: one fused pass
+  over the whole panel
+- **materialize-then-reduce**: build the full `(num_series, B, n)` tensor of
+  resampled paths, then reduce it
+- **per-series loop**: a Python loop calling `bootstrap_reduce` once per series
+
+| Series | Fused time (s) | Fused mem (MiB) | Materialize time (s) | Materialize mem (MiB) | Loop time (s) | Loop mem (MiB) |
+|-------:|---------------:|----------------:|----------------------:|----------------------:|--------------:|---------------:|
+| 100    | 0.0125 | 0.9   | 1.846 | 157.1   | 1.794 | 3.9  |
+| 1,000  | 0.0832 | 9.4   | 16.37 | 1,534.3 | 17.96 | 11.4 |
+| 10,000 | 0.821  | 108.4 | 185.7 | 15,336.7 | 180.6 | 86.4 |
+
+At 10,000 series the fused path is about 220x faster than the per-series loop
+on the time axis (per-series-loop baseline), about 226x faster than
+materialize-then-reduce on the time axis (materialize baseline), and about
+141x lighter than materialize-then-reduce on the memory axis (materialize
+baseline). Measured on a dedicated 8-vCPU Hetzner ccx33 box on 2026-07-14,
+tsbootstrap 0.7.0 (Python 3.12.3, numpy 2.4.6, numba 0.66.0), with the settled
+timing methodology in `_timing.py` (settling runs at the timed shape discarded,
+then the median of the recorded repeats reported).
+
+Memory values are peak-RSS deltas in binary megabytes (MiB, 2^20 bytes).
 
 ---
 
@@ -278,4 +314,4 @@ are the reciprocal of the settled-min ratio (`speedup = 1 / cc_red_r_min`).
 | Compute a single statistic per replicate (memory-efficient) | `bootstrap_reduce(x, ..., statistic=fn)` |
 | Compute a statistic, maximum throughput | `bootstrap_reduce(x, ..., statistic="mean", backend="compiled")` |
 | Multivariate (VAR) residual bootstrap at scale | `bootstrap_reduce(x, method=ResidualBootstrap(model=VAR(...)), ...)` |
-| Panel of many series | `bootstrap_reduce(panel, ...)` |
+| Panel of many series | `bootstrap_reduce_panel(panel, ...)` |

--- a/src/tsbootstrap/api.py
+++ b/src/tsbootstrap/api.py
@@ -694,7 +694,9 @@ def bootstrap_reduce_panel(
     representation is a list of per-series arrays (or a flat array plus a CSR ``indptr``),
     not the rectangular ``(n, d)`` that :func:`bootstrap_reduce` assumes. The output gains
     a series axis, and ``.values()`` is mathematically incoherent across unequal lengths,
-    so the reduce IS the panel API.
+    so the reduce IS the panel API. The compiled kernels consume the
+    flat-values-plus-offsets layout directly, so access is contiguous within each series
+    rather than per-element pointer chasing.
 
     Parameters
     ----------
@@ -737,6 +739,11 @@ def bootstrap_reduce_panel(
         ``.statistics`` of shape ``(n_bootstraps, num_series, |theta|)``, collapsed to
         ``(n_bootstraps, num_series)`` when the series are univariate and the statistic is
         scalar (mirroring the ``(B,)`` collapse of the rectangular reduce).
+
+        The reduce returns the full per-series bootstrap distribution of the statistic
+        (``n_bootstraps x num_series``), so quantile and tail workflows on an estimator
+        are served directly with no replicate tensor. Use the materializing path only
+        when the workflow consumes the resampled paths themselves.
     """
     if backend not in ("numpy", "compiled"):
         raise MethodConfigError(


### PR DESCRIPTION
## Summary

Documentation fixes and additions around the panel reduce API and its benchmark results.

- **Correct the panel API name in benchmarks/README.md.** The panel section and the usage table named `bootstrap_reduce` as the panel entry point; the panel API is `bootstrap_reduce_panel`. Both places now name the real function, and the section describes the two accepted input forms (a list of 1-D arrays, or a flat values array with CSR-style offsets).
- **Add the measured panel three-way results table** to the panel section of benchmarks/README.md: fused `bootstrap_reduce_panel`, materialize-then-reduce, and a per-series loop, at 100 / 1,000 / 10,000 series. Medians from a 2026-07-14 run on a dedicated 8-vCPU Hetzner ccx33 box with tsbootstrap 0.7.0 (Python 3.12.3, numpy 2.4.6, numba 0.66.0) under the settled timing methodology in `benchmarks/_timing.py`; memory values are peak-RSS deltas in binary megabytes (MiB). Every ratio names its baseline and axis in the same sentence, and a preamble sentence states that convention for the whole file.
- **Full-distribution guidance** in the top-level README's compiled-reduce section and in the `bootstrap_reduce_panel` docstring: the reduce returns the full per-series bootstrap distribution of the statistic (`n_bootstraps x num_series`), so quantile and tail workflows on an estimator are served directly with no replicate tensor; the materializing path is only needed when the workflow consumes the resampled paths themselves.
- **Input-layout note** in the `bootstrap_reduce_panel` docstring: the compiled kernels consume the flat-values-plus-offsets layout directly, so access is contiguous within each series rather than per-element pointer chasing.

Docstring-only changes to `src/tsbootstrap/api.py`; no signatures or behavior touched.